### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners for ifixai-ai/diagnostic.
+# Listed users are auto-requested for review on every PR and at least one
+# of them must approve before main can be updated.
+* @n-papaioannou @Sebabaian @dimneo @stefyi-4355


### PR DESCRIPTION
## Summary
- Add \`.github/CODEOWNERS\` listing all four maintainers (@n-papaioannou, @Sebabaian, @dimneo, @stefyi-4355) as owners of every path.

## Why now
Prerequisite for the branch protection rule about to be applied to \`main\` (require PR + 1 codeowner approval + CI green + no force-push + no deletion).

## Test plan
- [ ] CODEOWNERS file lints cleanly in the GitHub UI (no "unknown owner" warnings)
- [ ] All four listed users receive review requests on subsequent PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)