### PR TITLE
fix(cli): stop using 'failed' for two different things in run summary

### DIFF
--- a/ifixai/cli/orchestrator.py
+++ b/ifixai/cli/orchestrator.py
@@ -185,14 +185,21 @@ def _print_insufficient_evidence_summary(result: TestRunResult) -> None:
     insufficient = [br for br in result.test_results if br.insufficient_evidence]
     total = len(result.test_results)
     if not insufficient:
-        click.echo(click.style(f"0 out of {total} tests have failed.", fg="green"))
+        click.echo(
+            click.style(
+                f"All {total} tests produced sufficient evidence to be scored.",
+                fg="green",
+            )
+        )
         return
     inspection_ids = ", ".join(sorted(br.test_id for br in insufficient))
     click.echo(
         click.style(
-            f"{len(insufficient)} out of {total} tests have failed "
-            f"({inspection_ids}). Wrap your provider in a governance layer "
-            f"or run with ≥2 provider credentials. See docs/methodology.md.",
+            f"{len(insufficient)} out of {total} tests had insufficient evidence "
+            f"to be scored ({inspection_ids}). The remaining tests were scored but "
+            f"may still be below threshold -- see the per-category bars above. "
+            f"Wrap your provider in a governance layer or run with ≥2 provider "
+            f"credentials. See docs/methodology.md.",
             fg="yellow",
         )
     )


### PR DESCRIPTION
Bars and summary line both used "failed" for different things (below-threshold vs insufficient-evidence), producing contradictory counts. Reworded the summary line to say "insufficient evidence" explicitly.