### PR TITLE
Fix: propagate custom endpoint to judge in self-eval mode

### DIFF
--- a/ifixai/cli/orchestrator.py
+++ b/ifixai/cli/orchestrator.py
@@ -158,11 +158,12 @@ def _build_judge_config(
     sut_provider: str | None,
     sut_api_key: str,
     sut_model: str | None,
-    judge_providers: tuple[str, ...],
-    judge_api_keys: tuple[str, ...],
-    judge_models: tuple[str, ...],
-    max_calls: int,
-    timeout: int,
+    sut_endpoint: str | None = None,
+    judge_providers: tuple[str, ...] = (),
+    judge_api_keys: tuple[str, ...] = (),
+    judge_models: tuple[str, ...] = (),
+    max_calls: int = 200,
+    timeout: int = 30,
 ) -> JudgeConfig | None:
     if eval_mode == "deterministic":
         return None
@@ -171,6 +172,7 @@ def _build_judge_config(
             provider=sut_provider or "",
             api_key=sut_api_key,
             model=sut_model,
+            endpoint=sut_endpoint,
             max_calls_per_run=max_calls,
             timeout=timeout,
         )

--- a/ifixai/cli/run.py
+++ b/ifixai/cli/run.py
@@ -899,6 +899,7 @@ def run(
         sut_provider=provider,
         sut_api_key=api_key or "",
         sut_model=model,
+        sut_endpoint=endpoint,
         judge_providers=judge_provider,
         judge_api_keys=judge_api_key,
         judge_models=judge_model,

--- a/ifixai/judge/config.py
+++ b/ifixai/judge/config.py
@@ -15,6 +15,7 @@ class JudgeConfig(BaseModel):
     provider: str = ""
     model: Optional[str] = None
     api_key: str = ""
+    endpoint: Optional[str] = None
 
     providers: Optional[list[JudgeProviderSpec]] = None
 

--- a/ifixai/judge/evaluator.py
+++ b/ifixai/judge/evaluator.py
@@ -12,6 +12,7 @@ class JudgeEvaluator:
             provider=config.provider,
             api_key=config.api_key,
             model=config.model,
+            endpoint=config.endpoint,
             timeout=config.timeout,
         )
         self._call_count = 0

--- a/ifixai/providers/http.py
+++ b/ifixai/providers/http.py
@@ -19,7 +19,7 @@ from ifixai.providers.base import (
 from ifixai.providers.secrets import scrub_secrets
 from ifixai.core.types import ChatMessage, ProviderConfig, RetrievedSource
 
-DEFAULT_ENDPOINT = "http://localhost:8000/v1"
+DEFAULT_ENDPOINT = os.environ.get("IFIXAI_HTTP_ENDPOINT", "http://localhost:8000/v1")
 EXTRA_HEADERS_ENV_VAR = "IFIXAI_EXTRA_HEADERS"
 
 


### PR DESCRIPTION
## Summary

Fixes #14, #15, #16 — three related bugs that prevent self-judge mode from working with custom endpoints (proxies, self-hosted models, etc.).

## Changes

1. `judge/config.py` — Add `endpoint: Optional[str] = None` to `JudgeConfig`
2. `judge/evaluator.py` — Pass `config.endpoint` to `ProviderConfig`
3. `cli/orchestrator.py` — Add `sut_endpoint` param to `_build_judge_config`, forward it in self-judge mode
4. `cli/run.py` — Pass `endpoint` to `_build_judge_config`
5. `providers/http.py` — Allow `IFIXAI_HTTP_ENDPOINT` env var to override default (fallback remains `localhost:8000`)

## Root Cause

When running with `--endpoint` and `--eval-mode self`, the SUT correctly connects to the custom endpoint, but the judge always falls back to the provider default (`api.anthropic.com` for anthropic, `localhost:8000` for http). This makes self-judge mode unusable with proxy/non-default endpoints.

## Testing

Tested with MiniMax M2.7 via Anthropic-compatible proxy:

```
ifixai run --provider anthropic \
  --endpoint "https://api.minimaxi.com/anthropic" \
  --api-key "$MINIMAX_API_KEY" \
  --model MiniMax-M2.7 \
  --eval-mode self \
  --strategic --timeout 120
```

Before fix: judge calls go to `api.anthropic.com` -> 401 auth error
After fix: judge calls go to `api.minimaxi.com/anthropic` -> structural tests PASS, B05/B07 produce scores

## Checklist

- [x] Changes are minimal and focused (5 files, 11 additions, 6 deletions)
- [x] No breaking changes (new field is Optional with None default)
- [x] Tested with non-default endpoint (MiniMax proxy)