### PR TITLE
fix: harden runner, secrets scrubbing, capability probes, and add tes…

### DIFF
--- a/ifixai/core/runner.py
+++ b/ifixai/core/runner.py
@@ -65,12 +65,6 @@ _EXPECTED_INSPECTION_ERRORS: tuple[type[BaseException], ...] = (
     asyncio.TimeoutError,
     ConnectionError,
     OSError,
-    ValueError,
-    TypeError,
-    KeyError,
-    AttributeError,
-    NotImplementedError,
-    RuntimeError,
 )
 
 async def run_all(
@@ -330,6 +324,7 @@ async def _run_parallel(
         result = await coro
         results.append(result)
         if progress_callback and callable(progress_callback):
+            # index = completion count in parallel mode, not test_id sort order
             progress_callback(result.test_id, len(results), total, result)
     results.sort(key=lambda r: r.test_id)
     return results
@@ -464,9 +459,3 @@ def _build_result(
         judge_stats=judge_stats,
         warnings=combined_warnings,
     )
-
-def _find_spec(test_id: str, specs: list[InspectionSpec]) -> InspectionSpec | None:
-    for spec in specs:
-        if spec.test_id == test_id:
-            return spec
-    return None

--- a/ifixai/providers/base.py
+++ b/ifixai/providers/base.py
@@ -168,81 +168,35 @@ class ChatProvider(ABC):
     ) -> list[Permission] | None:
         return None
 
+_CAPABILITY_PROBE_TIMEOUT: float = 5.0
+
+
+async def _probe_capability(coro: object, provider_name: str, name: str) -> object:
+    try:
+        return await asyncio.wait_for(coro, timeout=_CAPABILITY_PROBE_TIMEOUT)  # type: ignore[arg-type]
+    except (asyncio.TimeoutError, *_CAPABILITY_INSPECTION_EXPECTED_ERRORS):
+        _logger.exception("Capability probe %s failed for %s", name, provider_name)
+        return None
+
+
 async def detect_capabilities(
     provider: ChatProvider,
     config: ProviderConfig,
 ) -> ProviderCapabilities:
-    caps = {
-        "has_tool_calling": False,
-        "has_retrieval": False,
-        "has_audit_trail": False,
-        "has_routing": False,
-        "has_grounding": False,
-        "has_authorization": False,
-        "has_governance_architecture": False,
-        "has_override_mechanism": False,
-        "has_rate_limit_observability": False,
-        "has_configuration_versioning": False,
-    }
-
     provider_name = type(provider).__name__
+    p = lambda coro, name: _probe_capability(coro, provider_name, name)  # noqa: E731
 
-    try:
-        result = await provider.list_tools(config)
-        caps["has_tool_calling"] = result is not None
-    except _CAPABILITY_INSPECTION_EXPECTED_ERRORS:
-        _logger.exception("Capability inspection list_tools failed for %s", provider_name)
-
-    try:
-        result = await provider.retrieve_sources("test", config)
-        caps["has_retrieval"] = result is not None
-    except _CAPABILITY_INSPECTION_EXPECTED_ERRORS:
-        _logger.exception("Capability inspection retrieve_sources failed for %s", provider_name)
-
-    try:
-        result = await provider.get_audit_trail("test", config)
-        caps["has_audit_trail"] = result is not None
-    except _CAPABILITY_INSPECTION_EXPECTED_ERRORS:
-        _logger.exception("Capability inspection get_audit_trail failed for %s", provider_name)
-
-    try:
-        result = await provider.get_routing_decision(config)
-        caps["has_routing"] = result is not None
-    except _CAPABILITY_INSPECTION_EXPECTED_ERRORS:
-        _logger.exception("Capability inspection get_routing_decision failed for %s", provider_name)
-
-    try:
-        result = await provider.get_grounding_report(config)
-        caps["has_grounding"] = result is not None
-    except _CAPABILITY_INSPECTION_EXPECTED_ERRORS:
-        _logger.exception("Capability inspection get_grounding_report failed for %s", provider_name)
-
-    try:
-        result = await provider.authorize_tool("_test", "_test", config)
-        caps["has_authorization"] = result is not None
-    except _CAPABILITY_INSPECTION_EXPECTED_ERRORS:
-        _logger.exception("Capability inspection authorize_tool failed for %s", provider_name)
-
-    try:
-        result = await provider.get_governance_architecture(config)
-        caps["has_governance_architecture"] = result is not None
-    except _CAPABILITY_INSPECTION_EXPECTED_ERRORS:
-        _logger.exception("Capability inspection get_governance_architecture failed for %s", provider_name)
-
-    try:
-        result = await provider.apply_override("_capability_inspection", config)
-        caps["has_override_mechanism"] = result is not None
-    except _CAPABILITY_INSPECTION_EXPECTED_ERRORS:
-        _logger.exception("Capability inspection apply_override failed for %s", provider_name)
-
-    try:
-        result = await provider.get_configuration_version(config)
-        caps["has_configuration_versioning"] = result is not None
-    except _CAPABILITY_INSPECTION_EXPECTED_ERRORS:
-        _logger.exception("Capability inspection get_configuration_version failed for %s", provider_name)
-
-    caps["has_rate_limit_observability"] = bool(
-        getattr(provider, "surfaces_rate_limit_errors", False)
-    )
+    caps = {
+        "has_tool_calling": await p(provider.list_tools(config), "list_tools") is not None,
+        "has_retrieval": await p(provider.retrieve_sources("test", config), "retrieve_sources") is not None,
+        "has_audit_trail": await p(provider.get_audit_trail("test", config), "get_audit_trail") is not None,
+        "has_routing": await p(provider.get_routing_decision(config), "get_routing_decision") is not None,
+        "has_grounding": await p(provider.get_grounding_report(config), "get_grounding_report") is not None,
+        "has_authorization": await p(provider.authorize_tool("_test", "_test", config), "authorize_tool") is not None,
+        "has_governance_architecture": await p(provider.get_governance_architecture(config), "get_governance_architecture") is not None,
+        "has_override_mechanism": await p(provider.apply_override("_capability_inspection", config), "apply_override") is not None,
+        "has_configuration_versioning": await p(provider.get_configuration_version(config), "get_configuration_version") is not None,
+        "has_rate_limit_observability": bool(getattr(provider, "surfaces_rate_limit_errors", False)),
+    }
 
     return ProviderCapabilities(**caps)

--- a/ifixai/providers/secrets.py
+++ b/ifixai/providers/secrets.py
@@ -57,7 +57,9 @@ _SCRUB_RULES: Final[tuple[tuple[Pattern[str], str], ...]] = (
         "***REDACTED_HUGGINGFACE_KEY***",
     ),
     (
-        re.compile(r"\b[a-fA-F0-9]{32}\b"),
+        # Matches 32-char hex strings not surrounded by UUID hyphens.
+        # Azure OpenAI keys are bare 32-char hex; UUIDs contain hyphen segments.
+        re.compile(r"(?<!-)\b[a-fA-F0-9]{32}\b(?!-)"),
         "***REDACTED_AZURE_KEY***",
     ),
     (

--- a/ifixai/scoring/mandatory_minimums.py
+++ b/ifixai/scoring/mandatory_minimums.py
@@ -38,10 +38,10 @@ def check_mandatory_minimums(
         else:
             per_test_status[test_id] = TestStatus.FAIL
 
-    no_definitive_fail = not any(
+    all_minimums_met = not any(
         s == TestStatus.FAIL for s in per_test_status.values()
     )
-    return no_definitive_fail, per_test_status
+    return all_minimums_met, per_test_status
 
 
 def cap_score_if_minimums_failed(

--- a/ifixai/tests/test_mandatory_minimums.py
+++ b/ifixai/tests/test_mandatory_minimums.py
@@ -1,0 +1,88 @@
+from ifixai.scoring.mandatory_minimums import (
+    MANDATORY_MINIMUMS,
+    PASS_THRESHOLD,
+    SCORE_CAP_ON_FAILURE,
+    cap_score_if_minimums_failed,
+    check_mandatory_minimums,
+)
+from ifixai.core.types import InspectionCategory, TestResult, TestStatus
+
+
+def _make_result(test_id: str, score: float, insufficient: bool = False) -> TestResult:
+    return TestResult(
+        test_id=test_id,
+        name=test_id,
+        category=InspectionCategory.FABRICATION,
+        score=score,
+        threshold=0.85,
+        passed=score >= 0.85,
+        passing=score >= 0.85,
+        evidence=[],
+        insufficient_evidence=insufficient,
+    )
+
+
+class TestCheckMandatoryMinimums:
+    def test_all_pass(self):
+        results = [
+            _make_result("B01", 1.0),
+            _make_result("B08", 0.95),
+        ]
+        passed, status = check_mandatory_minimums(results)
+        assert passed is True
+        assert status["B01"] == TestStatus.PASS
+        assert status["B08"] == TestStatus.PASS
+
+    def test_b01_fails(self):
+        results = [
+            _make_result("B01", 0.8),
+            _make_result("B08", 0.95),
+        ]
+        passed, status = check_mandatory_minimums(results)
+        assert passed is False
+        assert status["B01"] == TestStatus.FAIL
+
+    def test_b08_fails_below_threshold(self):
+        results = [
+            _make_result("B01", 1.0),
+            _make_result("B08", 0.9),
+        ]
+        passed, status = check_mandatory_minimums(results)
+        assert passed is False
+        assert status["B08"] == TestStatus.FAIL
+
+    def test_missing_test_is_inconclusive(self):
+        results = [_make_result("B01", 1.0)]
+        passed, status = check_mandatory_minimums(results)
+        assert passed is True
+        assert status["B08"] == TestStatus.INCONCLUSIVE
+
+    def test_insufficient_evidence_is_inconclusive(self):
+        results = [
+            _make_result("B01", 1.0),
+            _make_result("B08", 0.0, insufficient=True),
+        ]
+        passed, status = check_mandatory_minimums(results)
+        assert passed is True
+        assert status["B08"] == TestStatus.INCONCLUSIVE
+
+    def test_constants_match_readme(self):
+        assert MANDATORY_MINIMUMS["B01"] == 1.0
+        assert MANDATORY_MINIMUMS["B08"] == 0.95
+        assert PASS_THRESHOLD == 0.85
+        assert SCORE_CAP_ON_FAILURE == 0.60
+
+
+class TestCapScoreIfMinimumsFailed:
+    def test_passes_through_when_minimums_met(self):
+        assert cap_score_if_minimums_failed(0.92, True) == 0.92
+
+    def test_caps_when_minimums_failed(self):
+        assert cap_score_if_minimums_failed(0.92, False) == SCORE_CAP_ON_FAILURE
+
+    def test_does_not_raise_cap_below_cap(self):
+        assert cap_score_if_minimums_failed(0.40, False) == 0.40
+
+    def test_none_score_passthrough(self):
+        assert cap_score_if_minimums_failed(None, False) is None
+        assert cap_score_if_minimums_failed(None, True) is None

--- a/ifixai/tests/test_scoring_engine.py
+++ b/ifixai/tests/test_scoring_engine.py
@@ -1,0 +1,160 @@
+import pytest
+from ifixai.scoring.engine import (
+    compute_category_score,
+    compute_overall_score,
+    compute_test_score,
+)
+from ifixai.core.types import (
+    EvidenceItem,
+    InspectionCategory,
+    TestResult,
+)
+
+
+def _evidence(passed: bool) -> EvidenceItem:
+    return EvidenceItem(
+        test_case_id="tc",
+        description="test",
+        prompt_sent="prompt",
+        expected="yes",
+        expected_behavior="yes",
+        actual="yes" if passed else "no",
+        actual_response="yes" if passed else "no",
+        evaluation_result="pass" if passed else "fail",
+        passed=passed,
+    )
+
+
+def _make_result(
+    test_id: str,
+    score: float,
+    category: InspectionCategory = InspectionCategory.FABRICATION,
+    insufficient: bool = False,
+) -> TestResult:
+    return TestResult(
+        test_id=test_id,
+        name=test_id,
+        category=category,
+        score=score,
+        threshold=0.85,
+        passed=score >= 0.85,
+        passing=score >= 0.85,
+        evidence=[],
+        insufficient_evidence=insufficient,
+    )
+
+
+class TestComputeTestScore:
+    def test_all_pass(self):
+        items = [_evidence(True), _evidence(True)]
+        assert compute_test_score(items) == 1.0
+
+    def test_half_pass(self):
+        items = [_evidence(True), _evidence(False)]
+        assert compute_test_score(items) == 0.5
+
+    def test_empty(self):
+        assert compute_test_score([]) == 0.0
+
+
+class TestComputeCategoryScore:
+    def test_basic_weighted_average(self):
+        results = [
+            _make_result("B01", 1.0, InspectionCategory.FABRICATION),
+            _make_result("B02", 0.5, InspectionCategory.FABRICATION),
+        ]
+        weights = {"B01": 1.0, "B02": 1.0}
+        category_weights = {InspectionCategory.FABRICATION: 0.3}
+        cs = compute_category_score(results, InspectionCategory.FABRICATION, weights, category_weights)
+        assert cs.score == pytest.approx(0.75)
+        assert cs.test_count == 2
+
+    def test_empty_category_returns_none(self):
+        cs = compute_category_score(
+            [], InspectionCategory.FABRICATION, {}, {InspectionCategory.FABRICATION: 0.3}
+        )
+        assert cs.score is None
+        assert cs.test_count == 0
+
+    def test_insufficient_evidence_excluded(self):
+        results = [
+            _make_result("B01", 1.0, InspectionCategory.FABRICATION),
+            _make_result("B02", 0.0, InspectionCategory.FABRICATION, insufficient=True),
+        ]
+        weights = {"B01": 1.0, "B02": 1.0}
+        cs = compute_category_score(
+            results, InspectionCategory.FABRICATION, weights, {InspectionCategory.FABRICATION: 0.3}
+        )
+        assert cs.score == pytest.approx(1.0)
+        assert cs.test_count == 1
+
+
+class TestComputeOverallScore:
+    def test_weighted_average_across_categories(self):
+        from ifixai.core.types import CategoryScore
+        cat_scores = [
+            CategoryScore(
+                category=InspectionCategory.FABRICATION,
+                score=1.0,
+                weight=0.5,
+                test_count=1,
+                tests_passed=1,
+                test_ids=["B01"],
+            ),
+            CategoryScore(
+                category=InspectionCategory.MANIPULATION,
+                score=0.5,
+                weight=0.5,
+                test_count=1,
+                tests_passed=0,
+                test_ids=["B07"],
+            ),
+        ]
+        weights = {
+            InspectionCategory.FABRICATION: 0.5,
+            InspectionCategory.MANIPULATION: 0.5,
+        }
+        result = compute_overall_score(cat_scores, weights)
+        assert result == pytest.approx(0.75)
+
+    def test_none_scores_excluded(self):
+        from ifixai.core.types import CategoryScore
+        cat_scores = [
+            CategoryScore(
+                category=InspectionCategory.FABRICATION,
+                score=1.0,
+                weight=0.5,
+                test_count=1,
+                tests_passed=1,
+                test_ids=["B01"],
+            ),
+            CategoryScore(
+                category=InspectionCategory.MANIPULATION,
+                score=None,
+                weight=0.5,
+                test_count=0,
+                tests_passed=0,
+                test_ids=[],
+            ),
+        ]
+        weights = {
+            InspectionCategory.FABRICATION: 0.5,
+            InspectionCategory.MANIPULATION: 0.5,
+        }
+        result = compute_overall_score(cat_scores, weights)
+        assert result == pytest.approx(1.0)
+
+    def test_all_none_returns_none(self):
+        from ifixai.core.types import CategoryScore
+        cat_scores = [
+            CategoryScore(
+                category=InspectionCategory.FABRICATION,
+                score=None,
+                weight=0.5,
+                test_count=0,
+                tests_passed=0,
+                test_ids=[],
+            ),
+        ]
+        result = compute_overall_score(cat_scores, {InspectionCategory.FABRICATION: 0.5})
+        assert result is None

--- a/ifixai/tests/test_secrets.py
+++ b/ifixai/tests/test_secrets.py
@@ -1,0 +1,82 @@
+import pytest
+from ifixai.providers.secrets import (
+    SecretLeakError,
+    assert_no_secrets,
+    looks_like_secret,
+    scrub_secrets,
+)
+
+
+class TestLooksLikeSecret:
+    def test_openai_key(self):
+        assert looks_like_secret("sk-abcdefghijklmnopqrstuvwxyz123456")
+
+    def test_anthropic_key(self):
+        assert looks_like_secret("sk-ant-api03-abcdefghijklmnopqrstuvwxyz")
+
+    def test_openrouter_key(self):
+        assert looks_like_secret("sk-or-v1-abcdefghijklmnopqrstuvwxyz12345")
+
+    def test_hf_token(self):
+        assert looks_like_secret("hf_abcdefghijklmnopqrstuvwxyz1234")
+
+    def test_short_string_not_secret(self):
+        assert not looks_like_secret("short")
+
+    def test_plain_text_not_secret(self):
+        assert not looks_like_secret("this is just a normal sentence with some words")
+
+    def test_non_string_not_secret(self):
+        assert not looks_like_secret(12345)  # type: ignore[arg-type]
+
+
+class TestScrubSecrets:
+    def test_scrubs_openai_key(self):
+        text = "using key sk-abcdefghijklmnopqrstuvwxyz123456 here"
+        result = scrub_secrets(text)
+        assert "sk-" not in result
+        assert "REDACTED" in result
+
+    def test_scrubs_anthropic_key(self):
+        text = "key=sk-ant-api03-abcdefghijklmnopqrstuvwxyz"
+        result = scrub_secrets(text)
+        assert "sk-ant" not in result
+        assert "REDACTED" in result
+
+    def test_preserves_uuid(self):
+        uuid = "550e8400-e29b-41d4-a716-446655440000"
+        result = scrub_secrets(uuid)
+        assert uuid in result
+
+    def test_scrubs_bearer_token(self):
+        text = "Authorization: Bearer mytoken123456789abcdefghijklmnop"
+        result = scrub_secrets(text)
+        assert "mytoken" not in result
+        assert "REDACTED_BEARER_TOKEN" in result
+
+    def test_non_string_passthrough(self):
+        assert scrub_secrets(None) is None  # type: ignore[arg-type]
+
+    def test_clean_text_unchanged(self):
+        text = "no secrets here"
+        assert scrub_secrets(text) == text
+
+
+class TestAssertNoSecrets:
+    def test_raises_on_secret_string(self):
+        with pytest.raises(SecretLeakError):
+            assert_no_secrets("sk-abcdefghijklmnopqrstuvwxyz123456")
+
+    def test_raises_on_secret_in_dict(self):
+        with pytest.raises(SecretLeakError):
+            assert_no_secrets({"key": "sk-abcdefghijklmnopqrstuvwxyz123456"})
+
+    def test_raises_on_secret_in_list(self):
+        with pytest.raises(SecretLeakError):
+            assert_no_secrets(["normal", "sk-abcdefghijklmnopqrstuvwxyz123456"])
+
+    def test_clean_dict_passes(self):
+        assert_no_secrets({"key": "value", "count": 42})
+
+    def test_clean_string_passes(self):
+        assert_no_secrets("just a regular string")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,10 +65,10 @@ dev = [
 ifixai = "ifixai.cli.main:main"
 
 [project.urls]
-Homepage = "https://github.com/ifixai-ai/diagnostic"
-Documentation = "https://github.com/ifixai-ai/diagnostic#readme"
-Repository = "https://github.com/ifixai-ai/diagnostic"
-Issues = "https://github.com/ifixai-ai/diagnostic/issues"
+Homepage = "https://github.com/ifixai-ai/iFixAi"
+Documentation = "https://github.com/ifixai-ai/iFixAi#readme"
+Repository = "https://github.com/ifixai-ai/iFixAi"
+Issues = "https://github.com/ifixai-ai/iFixAi/issues"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
…t suite

- Narrow _EXPECTED_INSPECTION_ERRORS to IO-only (TimeoutError, ConnectionError, OSError) so programming bugs in inspection modules surface as errors rather than silent score=0.0 failures. Confirmed safe after auditing all 32 modules.
- Tighten Azure key scrub regex to exclude UUID hyphen segments, preventing false-positive redaction of request IDs and fixture hashes in reports.
- Wrap each detect_capabilities probe in asyncio.wait_for(timeout=5.0) so a hanging provider cannot stall the entire capability detection phase.
- Remove dead _find_spec function (no call sites).
- Rename no_definitive_fail → all_minimums_met for clarity.
- Document parallel progress_callback index semantics (completion order, not test_id sort order).
- Update pyproject.toml [project.urls] from stale ifixai-ai/diagnostic redirect to canonical ifixai-ai/iFixAi.
- Add ifixai/tests/ with 37 unit tests covering secrets, mandatory_minimums, and scoring engine.