### PR TITLE
feat: add LiteLLM as LLM provider

### DIFF
--- a/ifixai/providers/litellm.py
+++ b/ifixai/providers/litellm.py
@@ -1,0 +1,78 @@
+"""LiteLLM provider for iFixAi.
+
+Routes to 100+ LLM providers (OpenAI, Anthropic, Google, Azure, Bedrock,
+Ollama, etc.) via the litellm SDK. No proxy server needed.
+
+Install: pip install ifixai[litellm]
+
+See https://docs.litellm.ai/docs/providers for all supported models.
+"""
+
+import litellm as _litellm
+
+from ifixai.core.types import ChatMessage, ProviderConfig
+from ifixai.providers.base import (
+    ChatProvider,
+    ProviderConnectionError,
+    ProviderResponseError,
+    ProviderTimeoutError,
+)
+
+DEFAULT_MODEL = "openai/gpt-4o"
+
+
+class LiteLLMProvider(ChatProvider):
+    def __init__(self) -> None:
+        pass
+
+    async def send_message(
+        self,
+        messages: list[ChatMessage],
+        config: ProviderConfig,
+    ) -> str:
+        model = config.model or DEFAULT_MODEL
+        formatted_messages = [{"role": m.role, "content": m.content} for m in messages]
+
+        params = {
+            "model": model,
+            "messages": formatted_messages,
+            "drop_params": True,
+            "timeout": float(config.timeout),
+        }
+        if config.api_key:
+            params["api_key"] = config.api_key
+        if config.endpoint:
+            params["api_base"] = config.endpoint
+
+        try:
+            response = await _litellm.acompletion(**params)
+
+            content = response.choices[0].message.content
+            if not content:
+                raise ProviderResponseError(
+                    provider="litellm",
+                    endpoint=config.endpoint or "default",
+                    details="Empty content in response",
+                )
+            return content
+
+        except ProviderResponseError:
+            raise
+        except TimeoutError as exc:
+            raise ProviderTimeoutError(
+                provider="litellm",
+                endpoint=config.endpoint or "default",
+                details=str(exc),
+            ) from exc
+        except ConnectionError as exc:
+            raise ProviderConnectionError(
+                provider="litellm",
+                endpoint=config.endpoint or "default",
+                details=str(exc),
+            ) from exc
+        except Exception as exc:
+            raise ProviderResponseError(
+                provider="litellm",
+                endpoint=config.endpoint or "default",
+                details=str(exc),
+            ) from exc

--- a/ifixai/providers/resolver.py
+++ b/ifixai/providers/resolver.py
@@ -43,6 +43,11 @@ try:
 except ImportError:
     OpenRouterProvider = None
 
+try:
+    from ifixai.providers.litellm import LiteLLMProvider
+except ImportError:
+    LiteLLMProvider = None
+
 
 REGISTERED_PROVIDERS: tuple[str, ...] = (
     "http",
@@ -55,6 +60,7 @@ REGISTERED_PROVIDERS: tuple[str, ...] = (
     "bedrock",
     "huggingface",
     "langchain",
+    "litellm",
 )
 
 _MOCK_FIXTURE_PATH = Path(__file__).parent.parent / "fixtures" / "governance" / "mock.yaml"
@@ -71,6 +77,7 @@ _PROVIDER_MAP: dict[str, type] = {
         "bedrock": BedrockProvider,
         "huggingface": HuggingFaceProvider,
         "langchain": LangChainProvider,
+        "litellm": LiteLLMProvider,
     }.items()
     if cls is not None
 }
@@ -139,6 +146,7 @@ _PROVIDER_CREDENTIAL_ENV_VARS: dict[str, tuple[str, ...]] = {
     "bedrock": ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"),
     "huggingface": ("HUGGINGFACE_API_TOKEN", "HF_TOKEN"),
     "openrouter": ("OPENROUTER_API_KEY",),
+    "litellm": ("LITELLM_API_KEY",),
 }
 
 _JUDGE_PREFERENCE_ORDER: tuple[str, ...] = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,12 +43,14 @@ anthropic = ["anthropic>=0.18"]
 azure = ["openai>=1.0"]
 bedrock = ["boto3>=1.28"]
 huggingface = ["huggingface-hub>=0.20"]
+litellm = ["litellm>=1.60.0,<2.0.0"]
 all = [
     "openai>=1.0",
     "google-generativeai>=0.3",
     "anthropic>=0.18",
     "boto3>=1.28",
     "huggingface-hub>=0.20",
+    "litellm>=1.60.0,<2.0.0",
 ]
 dev = [
     "ruff>=0.4",

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,171 @@
+"""Tests for LiteLLM provider."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ifixai.core.types import ChatMessage, ProviderConfig
+from ifixai.providers.base import (
+    ChatProvider,
+    ProviderResponseError,
+    ProviderTimeoutError,
+)
+from ifixai.providers.litellm import LiteLLMProvider
+
+
+def _make_config(**overrides):
+    defaults = {
+        "provider": "litellm",
+        "model": "openai/gpt-4o",
+        "api_key": "sk-test",
+    }
+    defaults.update(overrides)
+    return ProviderConfig(**defaults)
+
+
+class TestLiteLLMProviderInit:
+    def test_extends_chat_provider(self):
+        assert issubclass(LiteLLMProvider, ChatProvider)
+
+    def test_instantiates_without_args(self):
+        p = LiteLLMProvider()
+        assert p is not None
+
+
+class TestSendMessage:
+    @pytest.mark.asyncio
+    @patch("ifixai.providers.litellm._litellm")
+    async def test_calls_acompletion_with_drop_params(self, mock_litellm):
+        mock_msg = MagicMock(content="test response")
+        mock_litellm.acompletion = AsyncMock(
+            return_value=MagicMock(choices=[MagicMock(message=mock_msg)])
+        )
+
+        p = LiteLLMProvider()
+        config = _make_config()
+        messages = [ChatMessage(role="user", content="hello")]
+        result = await p.send_message(messages, config)
+
+        assert result == "test response"
+        kwargs = mock_litellm.acompletion.call_args.kwargs
+        assert kwargs["drop_params"] is True
+        assert kwargs["model"] == "openai/gpt-4o"
+        assert kwargs["api_key"] == "sk-test"
+
+    @pytest.mark.asyncio
+    @patch("ifixai.providers.litellm._litellm")
+    async def test_omits_api_key_when_empty(self, mock_litellm):
+        mock_msg = MagicMock(content="ok")
+        mock_litellm.acompletion = AsyncMock(
+            return_value=MagicMock(choices=[MagicMock(message=mock_msg)])
+        )
+
+        p = LiteLLMProvider()
+        config = _make_config(api_key="")
+        messages = [ChatMessage(role="user", content="hi")]
+        await p.send_message(messages, config)
+
+        kwargs = mock_litellm.acompletion.call_args.kwargs
+        assert "api_key" not in kwargs
+
+    @pytest.mark.asyncio
+    @patch("ifixai.providers.litellm._litellm")
+    async def test_formats_messages_correctly(self, mock_litellm):
+        mock_msg = MagicMock(content="ok")
+        mock_litellm.acompletion = AsyncMock(
+            return_value=MagicMock(choices=[MagicMock(message=mock_msg)])
+        )
+
+        p = LiteLLMProvider()
+        config = _make_config()
+        messages = [
+            ChatMessage(role="system", content="be helpful"),
+            ChatMessage(role="user", content="hi"),
+        ]
+        await p.send_message(messages, config)
+
+        kwargs = mock_litellm.acompletion.call_args.kwargs
+        assert kwargs["messages"] == [
+            {"role": "system", "content": "be helpful"},
+            {"role": "user", "content": "hi"},
+        ]
+
+    @pytest.mark.asyncio
+    @patch("ifixai.providers.litellm._litellm")
+    async def test_uses_default_model_when_none(self, mock_litellm):
+        mock_msg = MagicMock(content="ok")
+        mock_litellm.acompletion = AsyncMock(
+            return_value=MagicMock(choices=[MagicMock(message=mock_msg)])
+        )
+
+        p = LiteLLMProvider()
+        config = _make_config(model=None)
+        messages = [ChatMessage(role="user", content="hi")]
+        await p.send_message(messages, config)
+
+        kwargs = mock_litellm.acompletion.call_args.kwargs
+        assert kwargs["model"] == "openai/gpt-4o"
+
+
+class TestEdgeCases:
+    @pytest.mark.asyncio
+    @patch("ifixai.providers.litellm._litellm")
+    async def test_empty_content_raises_response_error(self, mock_litellm):
+        mock_msg = MagicMock(content="")
+        mock_litellm.acompletion = AsyncMock(
+            return_value=MagicMock(choices=[MagicMock(message=mock_msg)])
+        )
+
+        p = LiteLLMProvider()
+        config = _make_config()
+        messages = [ChatMessage(role="user", content="hi")]
+
+        with pytest.raises(ProviderResponseError):
+            await p.send_message(messages, config)
+
+    @pytest.mark.asyncio
+    @patch("ifixai.providers.litellm._litellm")
+    async def test_api_error_raises_response_error(self, mock_litellm):
+        mock_litellm.acompletion = AsyncMock(side_effect=Exception("401 Unauthorized"))
+
+        p = LiteLLMProvider()
+        config = _make_config()
+        messages = [ChatMessage(role="user", content="hi")]
+
+        with pytest.raises(ProviderResponseError, match="401"):
+            await p.send_message(messages, config)
+
+    @pytest.mark.asyncio
+    @patch("ifixai.providers.litellm._litellm")
+    async def test_timeout_raises_timeout_error(self, mock_litellm):
+        mock_litellm.acompletion = AsyncMock(side_effect=TimeoutError("timed out"))
+
+        p = LiteLLMProvider()
+        config = _make_config()
+        messages = [ChatMessage(role="user", content="hi")]
+
+        with pytest.raises(ProviderTimeoutError):
+            await p.send_message(messages, config)
+
+
+class TestResolver:
+    def test_litellm_in_registered_providers(self):
+        from ifixai.providers.resolver import REGISTERED_PROVIDERS
+
+        assert "litellm" in REGISTERED_PROVIDERS
+
+    def test_litellm_in_provider_map(self):
+        from ifixai.providers.resolver import _PROVIDER_MAP
+
+        assert "litellm" in _PROVIDER_MAP
+
+    def test_resolve_litellm_returns_provider(self):
+        from ifixai.providers.resolver import resolve_provider
+
+        provider = resolve_provider("litellm")
+        assert isinstance(provider, LiteLLMProvider)
+
+    def test_litellm_in_credential_env_vars(self):
+        from ifixai.providers.resolver import _PROVIDER_CREDENTIAL_ENV_VARS
+
+        assert "litellm" in _PROVIDER_CREDENTIAL_ENV_VARS


### PR DESCRIPTION
                                                                                                                                                                                                                     
  ## Summary
  - Adds `LiteLLMProvider` as a new provider in `ifixai/providers/`, enabling access to 100+ LLM providers (OpenAI, Anthropic, Google, Azure, Bedrock, Ollama, etc.) via a single unified SDK                        
  - Extends `ChatProvider` with async `send_message()`, following the same pattern as `OpenAIProvider`, `AnthropicProvider`, `GeminiProvider`, etc.                                                                  
  - Fully registered in `resolver.py` (provider map, credential env vars, registered providers list)                                                                                                                 
                                                                                                                                                                                                                     

                                                                                                                                                                                                                     
  ## Changes      
  - `ifixai/providers/litellm.py` - new `LiteLLMProvider` extending `ChatProvider` with:
    - `litellm.acompletion()` for async completion                                                                                                                                                                   
    - `drop_params=True` for cross-provider kwargs compatibility
    - Error translation to `ProviderResponseError`, `ProviderTimeoutError`, `ProviderConnectionError`                                                                                                                
  - `ifixai/providers/resolver.py` - registered litellm in:
    - `REGISTERED_PROVIDERS` tuple                                                                                                                                                                                   
    - `_PROVIDER_MAP` dict (with try/except ImportError guard)
    - `_PROVIDER_CREDENTIAL_ENV_VARS` dict (`LITELLM_API_KEY`)                                                                                                                                                       
  - `pyproject.toml` - added `litellm>=1.60.0,<2.0.0` as optional dependency (`pip install ifixai[litellm]`) and in `all` extra                                                                                      
  - `tests/test_litellm_provider.py` - 13 unit tests (all passing)                                                                                                                                                   
                                                                                                                                                                                                                     
  ## Tests                                                                                                                                                                       
                  
  **Unit tests (13/13 passing):**
  ```
  $ PYTHONPATH=. python -m pytest tests/test_litellm_provider.py -v
  test_extends_chat_provider PASSED                                                                                                                                                                                  
  test_instantiates_without_args PASSED
  test_calls_acompletion_with_drop_params PASSED                                                                                                                                                                     
  test_omits_api_key_when_empty PASSED                                                                                                                                                                               
  test_formats_messages_correctly PASSED
  test_uses_default_model_when_none PASSED                                                                                                                                                                           
  test_empty_content_raises_response_error PASSED
  test_api_error_raises_response_error PASSED                                                                                                                                                                        
  test_timeout_raises_timeout_error PASSED                                                                                                                                                                           
  test_litellm_in_registered_providers PASSED
  test_litellm_in_provider_map PASSED                                                                                                                                                                                
  test_resolve_litellm_returns_provider PASSED
  test_litellm_in_credential_env_vars PASSED                                                                                                                                                                         
  13 passed in 1.67s
  ```                                                                                                                                                                                                                
                  
  **Live E2E test (Azure Foundry, Claude):**                                                                                                                                                                         
  ```python
  from ifixai.providers.litellm import LiteLLMProvider                                                                                                                                                               
  from ifixai.core.types import ChatMessage, ProviderConfig
                                                                                                                                                                                                                     
  provider = LiteLLMProvider()
  config = ProviderConfig(                                                                                                                                                                                           
      provider="litellm",
      model="anthropic/claude-sonnet-4-6",                                                                                                                                                                           
      api_key=os.environ["ANTHROPIC_FOUNDRY_API_KEY"],
  )                                                                                                                                                                                                                  
  messages = [ChatMessage(role="user", content="What is 2+2? Reply with just the number.")]                                                                                                                          
  result = await provider.send_message(messages, config)
  print(result)  # "4"                                                                                                                                                                                               
  ```             
                                                                                                                                                                                                                     
  ```             
  Response: "4"
  E2E SUCCESS
  ```

  ## Example usage

  ```bash                                                                                                                                                                                                            
  pip install ifixai[litellm]
  ```                                                                                                                                                                                                                
                  
  ```python
  from ifixai.providers.resolver import resolve_provider
  from ifixai.core.types import ChatMessage, ProviderConfig
                                                                                                                                                                                                                     
  provider = resolve_provider("litellm")
  config = ProviderConfig(                                                                                                                                                                                           
      provider="litellm",
      model="anthropic/claude-sonnet-4-20250514",
      # LiteLLM reads ANTHROPIC_API_KEY from env automatically
  )                                                                                                                                                                                                                  
  messages = [ChatMessage(role="user", content="Analyze this model for bias...")]
  result = await provider.send_message(messages, config)                                                                                                                                                             
  ```             
                                                                                                                                                                                                                     
  See https://docs.litellm.ai/docs/providers for 100+ supported model strings.                                                                                                                                       
   
  ## Impact                                                                                                                                                                                                          
  - Additive only, existing providers (openai, anthropic, gemini, azure, bedrock, huggingface, openrouter) untouched
  - `litellm` is an optional dependency (`pip install ifixai[litellm]`)                                                                                                                                              
  - Import guarded with try/except in resolver, graceful fallback if not installed                                                                                                                                   
  - `drop_params=True` silently drops provider-unsupported kwargs                                                                                                                                                    
  - Same async `send_message()` interface as all other providers                                                                                                                                                     
  - Error types mapped to existing hierarchy (`ProviderResponseError`, `ProviderTimeoutError`, `ProviderConnectionError`)
