### PR TITLE
feat(cli): suite selector, scorecard insights, friendly provider errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ Every run has **two roles**, and a citable run needs a key for each:
 | **SUT** (system under test) | the agent/model being **graded** | `--provider` + `--api-key`; the SUT key is always passed explicitly, never read from the environment |
 | **Judge** | who **grades** it | auto-paired from a *different* provider whose key is in your environment (the SUT's own vendor is excluded, so it never grades itself) |
 
-Reports land in `./ifixai-results/` as JSON **and** Markdown. Without a second key, add
+Reports land in `./ifixai-results/`: a short `-summary.md` (start here, with an insights
+rollup of the weakest pillars and top failures), the full Markdown report, and JSON. Without a second key, add
 `--eval-mode self` to run as a smoke test (the grade still prints, but it's flagged as
 self-judged, not a result you can cite). Pinning the judge, Full-mode ensembles, and the eval modes:
 **[docs/running.md](docs/running.md)**. Other providers (OpenAI, OpenRouter, Gemini,
@@ -132,6 +133,20 @@ The more of those parts your adapter exposes, the more inspections iFixAi can ac
 score, instead of marking them `insufficient_evidence` (it couldn't see enough of your
 agent to judge; these are reported but don't count for or against your grade). Full
 walkthrough with the model-vs-agent coverage map: **[docs/testing-your-agent.md](docs/testing-your-agent.md)**.
+
+### Pick what to run
+
+A run executes all 45 inspections by default. Narrow it with a named **suite** instead of
+hand-listing IDs:
+
+```bash
+ifixai run --provider anthropic --api-key "$ANTHROPIC_API_KEY" --suite core      # the 32 graded pillars
+ifixai run --provider anthropic --api-key "$ANTHROPIC_API_KEY" --suite security  # injection, privilege escalation, sabotage
+```
+
+Tiers are `smoke`, `strategic`, `core`, `extended`, `all`; themes are `security`,
+`reliability`, `compliance`, `frontier`. Browse them with `ifixai list suites`, and the
+failure categories behind `--category` with `ifixai list categories`.
 
 ## What you get back
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Now try it yourself. In three commands you install iFixAi, check that it runs, t
 real model. The grade you get back is citable because a different vendor's AI does the grading,
 not the agent judging itself. Full walkthrough: **[docs/get-started.md](docs/get-started.md)**.
 
+Prefer not to memorize flags? Run `ifixai setup` for a guided wizard that writes a reusable
+`ifixai.yaml`, then just `ifixai run`. It never stores your key; the system-under-test key
+stays explicit at run time.
+
 ```bash
 # 1. Install the CLI + the extra for the provider you'll test
 pip install "ifixai[anthropic]"

--- a/ifixai/cli/config_file.py
+++ b/ifixai/cli/config_file.py
@@ -1,0 +1,72 @@
+"""Reusable run configuration persisted as ``ifixai.yaml``.
+
+Stores only non-secret run preferences (provider, model, fixture, suite, judges,
+...). It deliberately never stores or references the system-under-test API key:
+that key is always passed explicitly to ``ifixai run`` (or prompted for), never
+read from a config file, so a run can't silently grade the wrong credential.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ValidationError
+
+CONFIG_FILENAME = "ifixai.yaml"
+
+
+class JudgeSpec(BaseModel):
+    provider: str
+    model: str | None = None
+
+
+class RunConfig(BaseModel):
+    """Persisted defaults for ``ifixai run`` (every field optional)."""
+
+    provider: str | None = None
+    model: str | None = None
+    endpoint: str | None = None
+    fixture: str | None = None
+    suite: str | None = None
+    mode: str | None = None
+    eval_mode: str | None = None
+    judges: list[JudgeSpec] = []
+    output: str | None = None
+    format: str | None = None
+    timeout: int | None = None
+    name: str | None = None
+
+    def to_yaml(self) -> str:
+        data = self.model_dump(exclude_none=True)
+        if not self.judges:
+            data.pop("judges", None)
+        return yaml.safe_dump(data, sort_keys=False, default_flow_style=False)
+
+
+def config_path(start_dir: Path | None = None) -> Path:
+    return (start_dir or Path.cwd()) / CONFIG_FILENAME
+
+
+def load_config(start_dir: Path | None = None) -> RunConfig | None:
+    """Load ``ifixai.yaml`` from ``start_dir`` (cwd by default), or None."""
+    path = config_path(start_dir)
+    if not path.exists():
+        return None
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{CONFIG_FILENAME} is not valid YAML: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ValueError(f"{CONFIG_FILENAME} must contain a mapping at the top level.")
+    try:
+        return RunConfig(**raw)
+    except ValidationError as exc:
+        raise ValueError(f"{CONFIG_FILENAME} has invalid fields:\n{exc}") from exc
+
+
+def write_config(config: RunConfig, start_dir: Path | None = None) -> Path:
+    """Write ``config`` to ``ifixai.yaml`` and return the path."""
+    path = config_path(start_dir)
+    path.write_text(config.to_yaml(), encoding="utf-8")
+    return path

--- a/ifixai/cli/init.py
+++ b/ifixai/cli/init.py
@@ -68,7 +68,10 @@ def init(non_interactive: bool) -> None:
     )
 
     click.echo()
-    click.echo(click.style("Suggested first run:", bold=True))
+    click.echo(click.style("Recommended: guided setup (writes ifixai.yaml):", bold=True))
+    click.echo("  ifixai setup")
+    click.echo()
+    click.echo(click.style("Or run directly:", bold=True))
     click.echo(f"  {suggested_command}")
     click.echo()
     click.echo(

--- a/ifixai/cli/list_cmd.py
+++ b/ifixai/cli/list_cmd.py
@@ -2,6 +2,12 @@ import click
 
 from ifixai.api import list_tests as get_tests, list_fixtures as get_fixture_names
 from ifixai.core.fixture_loader import load_fixture
+from ifixai.harness.registry import (
+    CATEGORIES,
+    CATEGORY_DESCRIPTIONS,
+    get_tests_by_category,
+)
+from ifixai.harness.suites import suite_catalog
 
 
 @click.group("list")
@@ -47,6 +53,62 @@ def list_tests(verbose: bool) -> None:
 
     click.echo()
     click.echo(click.style("* = Strategic test (Top 8)", dim=True))
+    click.echo()
+
+
+@list_group.command("suites")
+def list_suites() -> None:
+    """List the named suites accepted by `ifixai run --suite`."""
+    rows = suite_catalog()
+
+    click.echo()
+    click.echo(click.style("ifixai Suites", bold=True))
+    click.echo()
+    header = f"{'Suite':<14} {'Kind':<8} {'Tests':>5}  Description"
+    click.echo(header)
+    click.echo("-" * len(header))
+    last_kind = None
+    for row in rows:
+        if last_kind is not None and row["kind"] != last_kind:
+            click.echo()
+        last_kind = row["kind"]
+        click.echo(
+            f"{row['name']:<14} {row['kind']:<8} "
+            f"{row['count']:>5}  {row['description']}"
+        )
+
+    click.echo()
+    click.echo(click.style("Run a suite:  ifixai run --provider <p> --suite core", dim=True))
+    click.echo()
+
+
+@list_group.command("categories")
+def list_categories() -> None:
+    """List the failure categories accepted by `ifixai run --category`."""
+    rows = []
+    for category_id in sorted(CATEGORIES):
+        category = CATEGORIES[category_id]
+        members = get_tests_by_category(category_id)
+        description = CATEGORY_DESCRIPTIONS.get(category_id, "")
+        tail = description.split("—", 1)[1].strip() if "—" in description else ""
+        rows.append([category.value, str(len(members)), tail])
+
+    click.echo()
+    click.echo(click.style("ifixai Categories", bold=True))
+    click.echo()
+    header = f"{'Category':<22} {'Tests':>5}  Description"
+    click.echo(header)
+    click.echo("-" * len(header))
+    for name, count, tail in rows:
+        click.echo(f"{name:<22} {count:>5}  {tail}")
+
+    click.echo()
+    click.echo(
+        click.style(
+            "Run a category:  ifixai run --provider <p> --category MANIPULATION",
+            dim=True,
+        )
+    )
     click.echo()
 
 

--- a/ifixai/cli/main.py
+++ b/ifixai/cli/main.py
@@ -6,6 +6,7 @@ import click
 
 from ifixai._version import VERSION
 from ifixai.cli.init import init
+from ifixai.cli.setup_cmd import setup
 from ifixai.cli.run import run
 from ifixai.cli.list_cmd import list_group
 from ifixai.cli.validate import validate
@@ -18,6 +19,7 @@ def ifixai_cli() -> None:
     pass
 
 
+ifixai_cli.add_command(setup)
 ifixai_cli.add_command(init)
 ifixai_cli.add_command(run)
 ifixai_cli.add_command(list_group, name="list")

--- a/ifixai/cli/main.py
+++ b/ifixai/cli/main.py
@@ -1,3 +1,5 @@
+import logging
+import os
 import sys
 
 import click
@@ -43,8 +45,35 @@ def _ensure_utf8_stdout() -> None:
     sys.stderr = _fix(sys.stderr)
 
 
+class _CleanFormatter(logging.Formatter):
+    """One-line log formatter that hides Python tracebacks unless in debug mode."""
+
+    def __init__(self, show_tracebacks: bool) -> None:
+        super().__init__("%(message)s")
+        self._show_tracebacks = show_tracebacks
+
+    def format(self, record: logging.LogRecord) -> str:
+        if not self._show_tracebacks and (record.exc_info or record.stack_info):
+            record = logging.makeLogRecord(record.__dict__)
+            record.exc_info = None
+            record.exc_text = None
+            record.stack_info = None
+        return super().format(record)
+
+
+def _configure_cli_logging() -> None:
+    """Install a clean console handler so runs aren't buried in tracebacks."""
+    debug = bool(os.environ.get("IFIXAI_DEBUG") or os.environ.get("IFIXAI_VERBOSE"))
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(_CleanFormatter(show_tracebacks=debug))
+    root = logging.getLogger()
+    root.handlers[:] = [handler]
+    root.setLevel(logging.DEBUG if debug else logging.WARNING)
+
+
 def main() -> None:
     _ensure_utf8_stdout()
+    _configure_cli_logging()
     ifixai_cli()
 
 

--- a/ifixai/cli/orchestrator.py
+++ b/ifixai/cli/orchestrator.py
@@ -210,6 +210,8 @@ def _print_error_summary(result: TestRunResult) -> None:
     Listing the affected test IDs lets operators see exactly which
     benchmarks did not execute.
     """
+    from ifixai.providers.base import friendly_provider_message
+
     errored = [br for br in result.test_results if br.status == TestStatus.ERROR]
     if not errored:
         return
@@ -224,9 +226,21 @@ def _print_error_summary(result: TestRunResult) -> None:
             bold=True,
         )
     )
+
+    grouped: dict[str, list[str]] = {}
     for br in errored:
         reason = br.error_message or br.error or "no detail available"
-        click.echo(click.style(f"  - {br.test_id}: {reason}", fg="red"))
+        grouped.setdefault(reason, []).append(br.test_id)
+
+    for reason, ids in grouped.items():
+        friendly = friendly_provider_message(reason)
+        affected = ", ".join(sorted(ids))
+        if friendly is not None:
+            click.echo(click.style(f"  {friendly}", fg="yellow", bold=True))
+            click.echo(click.style(f"    Affected: {affected}", fg="red"))
+            click.echo(click.style(f"    Details:  {reason}", dim=True))
+        else:
+            click.echo(click.style(f"  - {affected}: {reason}", fg="red"))
 
 
 def _print_inconclusive_summary(result: TestRunResult) -> None:

--- a/ifixai/cli/reports.py
+++ b/ifixai/cli/reports.py
@@ -6,6 +6,7 @@ import click
 from ifixai.reporting.scorecard import (
     generate_json_report,
     generate_markdown_report,
+    generate_summary_report,
 )
 from ifixai.core.types import TestRunResult
 
@@ -36,6 +37,10 @@ def save_reports(
         click.echo(f"  JSON report:      {json_path}")
 
     if report_format in ("markdown", "both"):
+        summary_path = out_path / f"{base_name}-summary.md"
+        summary_path.write_text(generate_summary_report(result), encoding="utf-8")
+        click.echo(f"  Summary (start here): {summary_path}")
+
         md_path = out_path / f"{base_name}.md"
         md_path.write_text(generate_markdown_report(result), encoding="utf-8")
         click.echo(f"  Markdown report:  {md_path}")

--- a/ifixai/cli/run.py
+++ b/ifixai/cli/run.py
@@ -18,6 +18,7 @@ from ifixai import __version__ as IFIXAI_VERSION
 from ifixai.cli._branding import (
     print_startup_banner,
 )
+from ifixai.cli.config_file import CONFIG_FILENAME, load_config
 from ifixai.cli._imecore_prompt import print_imecore_conclusion
 from ifixai.cli.orchestrator import (
     _build_judge_config,
@@ -160,6 +161,20 @@ def _resolve_concurrency(flag_value: int | None, no_parallel: bool) -> int:
         return env_value
 
     return DEFAULT_CONCURRENCY
+
+
+def _cfg_value(ctx: click.Context, name: str, current, cfg_value):
+    """Return cfg_value when the flag was left at its default, else current.
+
+    Implements flag > config > default precedence for non-secret run options.
+    """
+    from click.core import ParameterSource
+
+    if cfg_value is None:
+        return current
+    if ctx.get_parameter_source(name) == ParameterSource.DEFAULT:
+        return cfg_value
+    return current
 
 
 def _format_elapsed(seconds: float) -> str:
@@ -571,7 +586,9 @@ def _print_concurrency_banner(resolved: int) -> None:
     help="Suppress the startup banner and the post-run iMe Core conclusion. "
     "Stdout still contains scores so CI gates keep working.",
 )
+@click.pass_context
 def run(
+    ctx: click.Context,
     provider: str | None,
     api_key: str | None,
     fixture: str,
@@ -615,6 +632,49 @@ def run(
 ) -> None:
     """Run ifixai against a target AI assistant."""
     run_start_monotonic = time.monotonic()
+
+    try:
+        config_obj = load_config()
+    except ValueError as exc:
+        click.echo(click.style(f"Config error: {exc}", fg="red"), err=True)
+        sys.exit(1)
+    if config_obj is not None:
+        from click.core import ParameterSource
+
+        provider = _cfg_value(ctx, "provider", provider, config_obj.provider)
+        model = _cfg_value(ctx, "model", model, config_obj.model)
+        fixture = _cfg_value(ctx, "fixture", fixture, config_obj.fixture)
+        endpoint = _cfg_value(ctx, "endpoint", endpoint, config_obj.endpoint)
+        run_mode = _cfg_value(ctx, "run_mode", run_mode, config_obj.mode)
+        eval_mode = _cfg_value(ctx, "eval_mode", eval_mode, config_obj.eval_mode)
+        output = _cfg_value(ctx, "output", output, config_obj.output)
+        report_format = _cfg_value(ctx, "report_format", report_format, config_obj.format)
+        timeout = _cfg_value(ctx, "timeout", timeout, config_obj.timeout)
+        system_name = _cfg_value(ctx, "system_name", system_name, config_obj.name)
+        explicit_selector = (
+            strategic
+            or bool(test)
+            or bool(categories)
+            or ctx.get_parameter_source("suite") != ParameterSource.DEFAULT
+        )
+        if config_obj.suite and not explicit_selector:
+            suite = config_obj.suite
+        if config_obj.judges and (
+            ctx.get_parameter_source("judge_provider") == ParameterSource.DEFAULT
+        ):
+            judge_provider = tuple(j.provider for j in config_obj.judges)
+            if any(j.model for j in config_obj.judges):
+                judge_model = tuple((j.model or "") for j in config_obj.judges)
+            # Judge keys are env-paired by design (a judge from a different vendor
+            # whose key is in the environment). The SUT key is NOT read here.
+            judge_api_key = tuple(
+                _lookup_env_api_key(j.provider) or "" for j in config_obj.judges
+            )
+        if not quiet:
+            click.echo(
+                click.style(f"Using config: {CONFIG_FILENAME}", fg="cyan"), err=True
+            )
+
     if run_nonce is not None and not is_valid_run_nonce(run_nonce):
         raise click.BadParameter(
             f"--run-nonce must be 16 lowercase hex chars; got {run_nonce!r}",

--- a/ifixai/cli/run.py
+++ b/ifixai/cli/run.py
@@ -59,6 +59,7 @@ from ifixai.harness.registry import (
     SPEC_BY_ID,
     resolve_category_test_ids,
 )
+from ifixai.harness.suites import SUITE_NAMES, resolve_suite
 from ifixai.utils.fixture_digest import compute_fixture_digest
 from ifixai.utils.rubric_digest import compute_rubric_digests_for_tests_layout
 from ifixai.core.grounding import GroundingMode, compose_system_prompt
@@ -182,16 +183,20 @@ def _describe_filter(
     strategic: bool,
     test: tuple[str, ...],
     categories: tuple[str, ...],
+    suite: str | None = None,
 ) -> str:
     """Human-readable summary of which tests the run will execute.
 
     ``test`` is the already-merged selection (explicit -b IDs plus any IDs
-    expanded from ``categories``); ``categories`` is the raw, unexpanded set
-    of category names so the label can name them.
+    expanded from ``suite`` and ``categories``); ``categories`` and ``suite``
+    are the raw, unexpanded selectors so the label can name them.
     """
+    if suite and not categories:
+        return f"suite '{suite.strip().lower()}' -> {len(test)} tests"
     if categories:
         names = ", ".join(name.strip().upper() for name in categories)
-        return f"categories ({names}) -> {len(test)} tests"
+        prefix = f"suite '{suite.strip().lower()}' + " if suite else ""
+        return f"{prefix}categories ({names}) -> {len(test)} tests"
     if strategic:
         return "strategic (top 8)"
     if test:
@@ -305,6 +310,14 @@ def _print_concurrency_banner(resolved: int) -> None:
     "(e.g. -c DECEPTION -c SYSTEMIC_RISK). Case-insensitive. Repeat to "
     "select several categories; combine with -b to add individual tests. "
     "Takes precedence over --strategic.",
+)
+@click.option(
+    "--suite",
+    default=None,
+    help="Run a named suite. Tiers: smoke, strategic, core (32 graded), "
+    "extended (13 frontier), all. Themes: security, reliability, compliance, "
+    "frontier. Folds into the selection like --category; combine with -b/-c to "
+    "add more. Run `ifixai list suites` to browse.",
 )
 @click.option(
     "--output",
@@ -569,6 +582,7 @@ def run(
     strategic: bool,
     test: tuple[str, ...],
     categories: tuple[str, ...],
+    suite: str | None,
     output: str,
     report_format: str,
     timeout: int,
@@ -740,6 +754,23 @@ def run(
         api_key = click.prompt("API key", hide_input=True)
 
     resolved_name = system_name or provider
+
+    if suite:
+        suite_resolution = resolve_suite(suite)
+        if suite_resolution["unknown"]:
+            click.echo(
+                click.style(
+                    f"Error: unknown suite '{suite}'. "
+                    f"Available: {', '.join(SUITE_NAMES)}",
+                    fg="red",
+                )
+            )
+            sys.exit(1)
+        test = tuple(
+            dict.fromkeys(
+                [*(tid.upper() for tid in test), *suite_resolution["test_ids"]]
+            )
+        )
 
     if categories:
         resolution = resolve_category_test_ids(categories)
@@ -1055,7 +1086,7 @@ def run(
     click.echo(click.style("ifixai Run", bold=True))
     click.echo(f"  Provider:  {provider}")
     click.echo(f"  Fixture:   {fixture}")
-    click.echo(f"  Filter:    {_describe_filter(strategic, test, categories)}")
+    click.echo(f"  Filter:    {_describe_filter(strategic, test, categories, suite)}")
     click.echo(f"  Mode:      {run_mode}")
     click.echo(f"  Judge:     {judge_label}")
     click.echo(f"  Timeout:   {timeout}s")

--- a/ifixai/cli/run.py
+++ b/ifixai/cli/run.py
@@ -1304,7 +1304,14 @@ def run(
         if result.passed
         else click.style("FAIL", fg="red")
     )
-    click.echo(f"  {score_label}    {result.overall_score:.1%}{coverage_suffix}")
+    capped_note = (
+        click.style(
+            f" (capped from {result.overall_score_before_cap:.1%})", fg="yellow"
+        )
+        if result.overall_score_before_cap is not None
+        else ""
+    )
+    click.echo(f"  {score_label}    {result.overall_score:.1%}{capped_note}{coverage_suffix}")
     click.echo(f"  Grade:            {result.grade.value}")
     click.echo(f"  Strategic Score:  {result.strategic_score:.1%}")
     click.echo(f"  Passed:           {verdict}")

--- a/ifixai/cli/setup_cmd.py
+++ b/ifixai/cli/setup_cmd.py
@@ -1,0 +1,237 @@
+"""``ifixai setup`` — guided wizard that writes ifixai.yaml and can run it.
+
+Uses only click's built-in prompts (no extra TUI dependencies). It never asks
+for or stores the system-under-test API key: that stays explicit, supplied to
+``ifixai run`` at run time (or prompted for).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import click
+
+from ifixai._version import VERSION as IFIXAI_VERSION
+from ifixai.cli._branding import print_startup_banner
+from ifixai.cli.config_file import CONFIG_FILENAME, JudgeSpec, RunConfig, write_config
+from ifixai.cli.init import PROVIDER_ENV_KEYS, detect_available_providers
+from ifixai.core.fixture_loader import list_fixture_names, load_fixture
+from ifixai.harness.suites import suite_catalog
+
+_PROVIDER_DESCRIPTIONS: dict[str, str] = {
+    "openrouter": "One key, many models (OpenAI, Anthropic, Google, Llama, ...)",
+    "openai": "OpenAI API (GPT-4o / o-series)",
+    "anthropic": "Anthropic API (Claude family)",
+    "gemini": "Google Gemini",
+    "azure": "Azure OpenAI deployment",
+    "bedrock": "AWS Bedrock-hosted models",
+    "huggingface": "Hugging Face Inference endpoints",
+    "http": "Any OpenAI-compatible HTTP endpoint",
+    "langchain": "A LangChain-wrapped model",
+    "mock": "Built-in offline mock (no key, just to try the tool)",
+}
+
+_ALL_PROVIDERS = [
+    "openrouter",
+    "openai",
+    "anthropic",
+    "gemini",
+    "azure",
+    "bedrock",
+    "huggingface",
+    "http",
+    "langchain",
+    "mock",
+]
+
+
+def _select(
+    prompt: str,
+    options: list[str],
+    *,
+    default: str,
+    descriptions: dict[str, str] | None = None,
+) -> str:
+    """Numbered single-choice menu via click prompts (no TUI deps)."""
+    click.echo()
+    click.echo(click.style(prompt, bold=True))
+    descriptions = descriptions or {}
+    for i, opt in enumerate(options, 1):
+        desc = descriptions.get(opt, "")
+        suffix = f"  {click.style('— ' + desc, dim=True)}" if desc else ""
+        click.echo(f"  {i}) {opt}{suffix}")
+    default_idx = options.index(default) + 1 if default in options else 1
+    chosen = click.prompt(
+        "Choose a number",
+        type=click.IntRange(1, len(options)),
+        default=default_idx,
+        show_default=True,
+    )
+    return options[chosen - 1]
+
+
+def _pick_model(provider: str, *, role: str) -> str | None:
+    """Free-text model id; blank means use the provider's default model."""
+    value = click.prompt(
+        f"Model id for the {role} (blank = provider default)",
+        default="",
+        show_default=False,
+    ).strip()
+    return value or None
+
+
+@click.command()
+def setup() -> None:
+    """Interactively configure a run and save it to ifixai.yaml."""
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        click.echo(
+            click.style(
+                "Error: `ifixai setup` needs an interactive terminal.\n"
+                "In a script or CI, use explicit flags, e.g.:\n"
+                "  ifixai run --provider openai --suite core --mode standard",
+                fg="red",
+            ),
+            err=True,
+        )
+        raise SystemExit(1)
+
+    print_startup_banner(IFIXAI_VERSION)
+    click.echo(click.style("Guided setup: a few prompts, then run with no flags.", bold=True))
+
+    available = [p for p, _ in detect_available_providers()]
+    if available:
+        click.echo(click.style(f"✓ Keys detected for: {', '.join(available)}", fg="green"))
+    else:
+        click.echo(click.style("No provider keys detected in your environment.", fg="yellow"))
+
+    provider_choices = available + [p for p in _ALL_PROVIDERS if p not in available]
+    provider_desc = {
+        p: _PROVIDER_DESCRIPTIONS.get(p, "") + (" [key detected]" if p in available else "")
+        for p in provider_choices
+    }
+    provider = _select(
+        "Which provider hosts the system under test (the model being graded)?",
+        provider_choices,
+        default=available[0] if available else "openrouter",
+        descriptions=provider_desc,
+    )
+
+    key_env = PROVIDER_ENV_KEYS.get(provider)
+    if provider != "mock" and key_env and provider not in available:
+        click.echo(
+            click.style(
+                f"  Note: export {key_env} before running, or `run` will prompt for the key.",
+                fg="yellow",
+            )
+        )
+
+    model = _pick_model(provider, role="system under test")
+
+    endpoint = None
+    if provider == "http":
+        endpoint = click.prompt("HTTP endpoint URL").strip() or None
+
+    click.echo()
+    click.echo(
+        click.style(
+            "Judges grade the answers. A judge from a DIFFERENT vendor gives a citable "
+            "score; none = self-judge (advisory, redacted). Judge keys are read from "
+            "your environment at run time.",
+            dim=True,
+        )
+    )
+    judge_candidates = sorted(set(available) | {provider})
+    judges: list[JudgeSpec] = []
+    while click.confirm(
+        f"Add {'an' if not judges else 'another'} independent judge?",
+        default=not judges,
+    ):
+        jp = _select(
+            f"Judge #{len(judges) + 1} provider:",
+            judge_candidates,
+            default=next((p for p in judge_candidates if p != provider), provider),
+            descriptions={p: _PROVIDER_DESCRIPTIONS.get(p, "") for p in judge_candidates},
+        )
+        jm = _pick_model(jp, role=f"judge #{len(judges) + 1}")
+        judges.append(JudgeSpec(provider=jp, model=jm))
+        click.echo(click.style(f"  ✓ Judge #{len(judges)}: {jp} / {jm or 'default'}", fg="green"))
+
+    fixtures = list_fixture_names()
+    fixture_desc = {}
+    for name in fixtures:
+        try:
+            fx = load_fixture(name)
+            fixture_desc[name] = fx.metadata.domain or fx.metadata.name or name
+        except Exception:
+            fixture_desc[name] = name
+    fixture = _select(
+        "Fixture (the deployment profile to test against):",
+        fixtures,
+        default="default" if "default" in fixtures else fixtures[0],
+        descriptions=fixture_desc,
+    )
+
+    suite_rows = suite_catalog()
+    suite_names = [str(r["name"]) for r in suite_rows]
+    suite_desc = {str(r["name"]): f"{r['count']} inspections, {r['description']}" for r in suite_rows}
+    suite = _select(
+        "Suite (which inspections to run):",
+        suite_names,
+        default="core" if "core" in suite_names else suite_names[0],
+        descriptions=suite_desc,
+    )
+
+    mode = _select(
+        "Run mode:",
+        ["standard", "full"],
+        default="standard",
+        descriptions={
+            "standard": "CI-friendly; one judge auto-paired from your env.",
+            "full": "Reference-grade; needs a hand-built fixture and >=2 judges.",
+        },
+    )
+    if mode == "full" and len(judges) < 2:
+        click.echo(
+            click.style(
+                "  Note: --mode full needs >=2 judges; add a second or it is rejected at run time.",
+                fg="yellow",
+            )
+        )
+
+    # Leave eval_mode unset unless an ensemble is configured, so `run` picks the
+    # best available mode (auto-pairing a judge from the environment) by default.
+    eval_mode = "full" if len(judges) >= 2 else None
+
+    config = RunConfig(
+        provider=provider,
+        model=model,
+        endpoint=endpoint,
+        fixture=fixture,
+        suite=suite,
+        mode=mode,
+        eval_mode=eval_mode,
+        judges=judges,
+    )
+
+    click.echo()
+    click.echo(click.style("Your configuration:", bold=True))
+    click.echo(config.to_yaml())
+
+    if not click.confirm(f"Save to {CONFIG_FILENAME}?", default=True):
+        click.echo("Aborted, nothing written.")
+        return
+    path = write_config(config)
+    click.echo(click.style(f"✓ Saved {path}", fg="green"))
+    click.echo()
+
+    if click.confirm("Run iFixAi now?", default=True):
+        cmd = [sys.executable, "-m", "ifixai.cli.main", "run"]
+        if provider == "mock":
+            cmd += ["-k", "unused"]
+        click.echo()
+        subprocess.run(cmd)
+    else:
+        click.echo(click.style("When you're ready, just run:  ", bold=True) + click.style("ifixai run", fg="cyan"))
+        if provider != "mock" and key_env:
+            click.echo(click.style(f"  (export {key_env} first, or it will prompt for the key)", dim=True))

--- a/ifixai/cli/setup_cmd.py
+++ b/ifixai/cli/setup_cmd.py
@@ -7,15 +7,16 @@ for or stores the system-under-test API key: that stays explicit, supplied to
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
+from pathlib import Path
 
 import click
 
 from ifixai._version import VERSION as IFIXAI_VERSION
 from ifixai.cli._branding import print_startup_banner
 from ifixai.cli.config_file import (
-    CONFIG_FILENAME,
     JudgeSpec,
     RunConfig,
     config_path,
@@ -41,19 +42,18 @@ _PROVIDER_DESCRIPTIONS: dict[str, str] = {
 }
 
 # Providers that front a bare model API vs transports for a wrapped agent.
-# Illustrative only (shown as "e.g. ..." hints) — NOT a pinned catalog, since
-# model slugs rot. Blank always falls back to the provider's own default.
-_MODEL_HINTS: dict[str, str] = {
-    "openrouter": "anthropic/claude-sonnet-4-6",
-    "openai": "gpt-4o",
-    "anthropic": "claude-sonnet-4-6",
-    "gemini": "gemini-2.5-flash-lite",
-    "azure": "your-deployment-name",
-    "bedrock": "a Bedrock model id",
-    "huggingface": "an HF repo id",
-    "http": "the served model id",
-    "langchain": "the wrapped model id",
-}
+_PROVIDERS_DIR = Path(__file__).resolve().parents[1] / "providers"
+
+
+def _provider_default_model(provider: str) -> str | None:
+    """The provider's DEFAULT_MODEL, read from source (no SDK import, no drift)."""
+    try:
+        text = (_PROVIDERS_DIR / f"{provider}.py").read_text(encoding="utf-8")
+    except OSError:
+        return None
+    m = re.search(r'^DEFAULT_MODEL\s*=\s*["\']([^"\']+)["\']', text, re.MULTILINE)
+    return m.group(1) if m else None
+
 
 _MODEL_PROVIDERS = [
     "openrouter",
@@ -103,11 +103,14 @@ def _select(
 
 def _pick_model(provider: str, *, role: str) -> str | None:
     """Free-text model id; blank means use the provider's default model."""
-    hint = _MODEL_HINTS.get(provider)
-    example = f"e.g. {hint}, " if hint else ""
-    suffix = click.style(f"({example}blank = provider default)", dim=True)
+    default_model = _provider_default_model(provider)
+    label = (
+        f"(blank = provider default: {default_model})"
+        if default_model
+        else "(blank = provider default)"
+    )
     value = click.prompt(
-        f"Model id for the {role} {suffix}",
+        f"Model id for the {role} {click.style(label, dim=True)}",
         default="",
         show_default=False,
     ).strip()
@@ -344,16 +347,11 @@ def setup() -> None:
     click.echo(click.style("  Will run:       ifixai run   (SUT key entered at run time, never saved)", dim=True))
 
     click.echo()
-    # Saving is the whole point of the wizard, so write by default; only stop to
-    # ask when an existing config would be overwritten.
-    if config_path().exists() and not click.confirm(
-        f"{CONFIG_FILENAME} already exists in this directory. Overwrite it?",
-        default=False,
-    ):
-        click.echo("Kept the existing config, nothing written.")
-        return
+    # Saving is the whole point of the wizard, and it must never block the run,
+    # so always write and continue (no save prompt).
+    existed = config_path().exists()
     path = write_config(config)
-    click.echo(click.style(f"✓ Saved {path}", fg="green"))
+    click.echo(click.style(f"✓ {'Updated' if existed else 'Saved'} {path}", fg="green"))
     click.echo()
 
     if click.confirm("Run iFixAi now?", default=True):

--- a/ifixai/cli/setup_cmd.py
+++ b/ifixai/cli/setup_cmd.py
@@ -14,7 +14,13 @@ import click
 
 from ifixai._version import VERSION as IFIXAI_VERSION
 from ifixai.cli._branding import print_startup_banner
-from ifixai.cli.config_file import CONFIG_FILENAME, JudgeSpec, RunConfig, write_config
+from ifixai.cli.config_file import (
+    CONFIG_FILENAME,
+    JudgeSpec,
+    RunConfig,
+    config_path,
+    write_config,
+)
 from ifixai.cli.init import PROVIDER_ENV_KEYS, detect_available_providers
 from ifixai.core.fixture_loader import list_fixture_names, load_fixture
 from ifixai.harness.suites import suite_catalog
@@ -35,6 +41,20 @@ _PROVIDER_DESCRIPTIONS: dict[str, str] = {
 }
 
 # Providers that front a bare model API vs transports for a wrapped agent.
+# Illustrative only (shown as "e.g. ..." hints) — NOT a pinned catalog, since
+# model slugs rot. Blank always falls back to the provider's own default.
+_MODEL_HINTS: dict[str, str] = {
+    "openrouter": "anthropic/claude-sonnet-4-6",
+    "openai": "gpt-4o",
+    "anthropic": "claude-sonnet-4-6",
+    "gemini": "gemini-2.5-flash-lite",
+    "azure": "your-deployment-name",
+    "bedrock": "a Bedrock model id",
+    "huggingface": "an HF repo id",
+    "http": "the served model id",
+    "langchain": "the wrapped model id",
+}
+
 _MODEL_PROVIDERS = [
     "openrouter",
     "openai",
@@ -83,8 +103,11 @@ def _select(
 
 def _pick_model(provider: str, *, role: str) -> str | None:
     """Free-text model id; blank means use the provider's default model."""
+    hint = _MODEL_HINTS.get(provider)
+    example = f"e.g. {hint}, " if hint else ""
+    suffix = click.style(f"({example}blank = provider default)", dim=True)
     value = click.prompt(
-        f"Model id for the {role} (blank = provider default)",
+        f"Model id for the {role} {suffix}",
         default="",
         show_default=False,
     ).strip()
@@ -321,8 +344,13 @@ def setup() -> None:
     click.echo(click.style("  Will run:       ifixai run   (SUT key entered at run time, never saved)", dim=True))
 
     click.echo()
-    if not click.confirm(f"Save to {CONFIG_FILENAME}?", default=True):
-        click.echo("Aborted, nothing written.")
+    # Saving is the whole point of the wizard, so write by default; only stop to
+    # ask when an existing config would be overwritten.
+    if config_path().exists() and not click.confirm(
+        f"{CONFIG_FILENAME} already exists in this directory. Overwrite it?",
+        default=False,
+    ):
+        click.echo("Kept the existing config, nothing written.")
         return
     path = write_config(config)
     click.echo(click.style(f"✓ Saved {path}", fg="green"))

--- a/ifixai/cli/setup_cmd.py
+++ b/ifixai/cli/setup_cmd.py
@@ -19,6 +19,8 @@ from ifixai.cli.init import PROVIDER_ENV_KEYS, detect_available_providers
 from ifixai.core.fixture_loader import list_fixture_names, load_fixture
 from ifixai.harness.suites import suite_catalog
 
+_TOTAL_STEPS = 5
+
 _PROVIDER_DESCRIPTIONS: dict[str, str] = {
     "openrouter": "One key, many models (OpenAI, Anthropic, Google, Llama, ...)",
     "openai": "OpenAI API (GPT-4o / o-series)",
@@ -27,12 +29,13 @@ _PROVIDER_DESCRIPTIONS: dict[str, str] = {
     "azure": "Azure OpenAI deployment",
     "bedrock": "AWS Bedrock-hosted models",
     "huggingface": "Hugging Face Inference endpoints",
-    "http": "Any OpenAI-compatible HTTP endpoint",
-    "langchain": "A LangChain-wrapped model",
+    "http": "Any OpenAI-compatible HTTP endpoint (point at your agent)",
+    "langchain": "A LangChain-wrapped agent",
     "mock": "Built-in offline mock (no key, just to try the tool)",
 }
 
-_ALL_PROVIDERS = [
+# Providers that front a bare model API vs transports for a wrapped agent.
+_MODEL_PROVIDERS = [
     "openrouter",
     "openai",
     "anthropic",
@@ -40,10 +43,17 @@ _ALL_PROVIDERS = [
     "azure",
     "bedrock",
     "huggingface",
-    "http",
-    "langchain",
     "mock",
 ]
+_AGENT_PROVIDERS = ["http", "langchain"]
+
+
+def _step(n: int, title: str, subtitle: str = "") -> None:
+    """Print a numbered step header so the flow reads as discrete stages."""
+    click.echo()
+    click.echo(click.style(f"── Step {n} of {_TOTAL_STEPS} · {title} ", bold=True) + click.style("─" * 24, dim=True))
+    if subtitle:
+        click.echo(click.style(subtitle, dim=True))
 
 
 def _select(
@@ -81,6 +91,55 @@ def _pick_model(provider: str, *, role: str) -> str | None:
     return value or None
 
 
+def _judge_note(provider: str, available: list[str]) -> None:
+    """Tell the user to export a judge key if it isn't already in the env."""
+    env = PROVIDER_ENV_KEYS.get(provider)
+    if provider != "mock" and env and provider not in available:
+        click.echo(
+            click.style(
+                f"    Note: export {env} before running (judge keys are read from the env).",
+                fg="yellow",
+            )
+        )
+
+
+def _add_judge(
+    idx: int,
+    sut_provider: str,
+    candidates: list[str],
+    available: list[str],
+) -> JudgeSpec:
+    """Prompt for one judge, steering away from a non-independent same-vendor pick."""
+    desc = {p: _PROVIDER_DESCRIPTIONS.get(p, "") for p in candidates}
+    default = next((p for p in candidates if p != sut_provider), candidates[0])
+    while True:
+        jp = _select(f"Judge #{idx} provider:", candidates, default=default, descriptions=desc)
+        if jp == sut_provider:
+            click.echo(
+                click.style(
+                    f"  ⚠ {jp} is also the system under test — that is not an independent "
+                    "grade, so the score is not citable.",
+                    fg="yellow",
+                    bold=True,
+                )
+            )
+            if not click.confirm("  Use it anyway?", default=False):
+                continue
+        jm = _pick_model(jp, role=f"judge #{idx}")
+        _judge_note(jp, available)
+        click.echo(click.style(f"  ✓ Judge #{idx}: {jp} / {jm or 'provider default'}", fg="green"))
+        return JudgeSpec(provider=jp, model=jm)
+
+
+def _independence(judges: list[JudgeSpec], sut_provider: str) -> str:
+    """One-word verdict on whether the configured judges give a citable grade."""
+    if not judges:
+        return "self-judge (advisory, redacted)"
+    if any(j.provider == sut_provider for j in judges):
+        return "NOT independent (judge shares the SUT vendor)"
+    return "independent ✓"
+
+
 @click.command()
 def setup() -> None:
     """Interactively configure a run and save it to ifixai.yaml."""
@@ -97,7 +156,7 @@ def setup() -> None:
         raise SystemExit(1)
 
     print_startup_banner(IFIXAI_VERSION)
-    click.echo(click.style("Guided setup: a few prompts, then run with no flags.", bold=True))
+    click.echo(click.style("Guided setup: 5 steps, then run with no flags.", bold=True))
 
     available = [p for p, _ in detect_available_providers()]
     if available:
@@ -105,15 +164,38 @@ def setup() -> None:
     else:
         click.echo(click.style("No provider keys detected in your environment.", fg="yellow"))
 
-    provider_choices = available + [p for p in _ALL_PROVIDERS if p not in available]
+    # ── Step 1 · Target ────────────────────────────────────────────────
+    _step(1, "Target", "What you are grading: a bare model API, or your wrapped agent.")
+    target = _select(
+        "What are you testing?",
+        ["a bare model API", "an agent (system prompt, tools, retrieval)"],
+        default="a bare model API",
+    )
+    is_agent = target.startswith("an agent")
+    if is_agent:
+        click.echo(
+            click.style(
+                "  iFixAi reaches your agent as a black box. Point --provider http at an "
+                "OpenAI-compatible endpoint, or use langchain. Exposing capability hooks "
+                "(list_tools, get_audit_trail, authorize_tool, retrieve_sources) lets more "
+                "inspections score instead of 'insufficient_evidence'. See docs/testing-your-agent.md.",
+                dim=True,
+            )
+        )
+        ordered = _AGENT_PROVIDERS + _MODEL_PROVIDERS
+        provider_default = "http"
+    else:
+        ordered = available + [p for p in _MODEL_PROVIDERS if p not in available] + _AGENT_PROVIDERS
+        provider_default = available[0] if available else "openrouter"
+
     provider_desc = {
         p: _PROVIDER_DESCRIPTIONS.get(p, "") + (" [key detected]" if p in available else "")
-        for p in provider_choices
+        for p in ordered
     }
     provider = _select(
-        "Which provider hosts the system under test (the model being graded)?",
-        provider_choices,
-        default=available[0] if available else "openrouter",
+        "Which provider hosts it?",
+        ordered,
+        default=provider_default,
         descriptions=provider_desc,
     )
 
@@ -126,37 +208,29 @@ def setup() -> None:
             )
         )
 
-    model = _pick_model(provider, role="system under test")
-
     endpoint = None
     if provider == "http":
-        endpoint = click.prompt("HTTP endpoint URL").strip() or None
+        endpoint = click.prompt("  Endpoint URL (OpenAI-compatible)").strip() or None
 
-    click.echo()
-    click.echo(
-        click.style(
-            "Judges grade the answers. A judge from a DIFFERENT vendor gives a citable "
-            "score; none = self-judge (advisory, redacted). Judge keys are read from "
-            "your environment at run time.",
-            dim=True,
-        )
+    model = _pick_model(provider, role="system under test")
+
+    # ── Step 2 · Judge ─────────────────────────────────────────────────
+    _step(
+        2,
+        "Judge",
+        "Grades the answers. A DIFFERENT vendor makes the score citable; none = "
+        "self-judge (advisory, redacted). Judge keys come from your env at run time.",
     )
-    judge_candidates = sorted(set(available) | {provider})
+    judge_candidates = sorted(set(available) | set(_MODEL_PROVIDERS) | {provider})
     judges: list[JudgeSpec] = []
     while click.confirm(
         f"Add {'an' if not judges else 'another'} independent judge?",
         default=not judges,
     ):
-        jp = _select(
-            f"Judge #{len(judges) + 1} provider:",
-            judge_candidates,
-            default=next((p for p in judge_candidates if p != provider), provider),
-            descriptions={p: _PROVIDER_DESCRIPTIONS.get(p, "") for p in judge_candidates},
-        )
-        jm = _pick_model(jp, role=f"judge #{len(judges) + 1}")
-        judges.append(JudgeSpec(provider=jp, model=jm))
-        click.echo(click.style(f"  ✓ Judge #{len(judges)}: {jp} / {jm or 'default'}", fg="green"))
+        judges.append(_add_judge(len(judges) + 1, provider, judge_candidates, available))
 
+    # ── Step 3 · Fixture ───────────────────────────────────────────────
+    _step(3, "Fixture", "The deployment profile (role, tools, governance) to test against.")
     fixtures = list_fixture_names()
     fixture_desc = {}
     for name in fixtures:
@@ -166,38 +240,52 @@ def setup() -> None:
         except Exception:
             fixture_desc[name] = name
     fixture = _select(
-        "Fixture (the deployment profile to test against):",
+        "Fixture:",
         fixtures,
         default="default" if "default" in fixtures else fixtures[0],
         descriptions=fixture_desc,
     )
 
+    # ── Step 4 · Suite ─────────────────────────────────────────────────
+    _step(4, "Suite", "Which inspections to run.")
     suite_rows = suite_catalog()
     suite_names = [str(r["name"]) for r in suite_rows]
     suite_desc = {str(r["name"]): f"{r['count']} inspections, {r['description']}" for r in suite_rows}
     suite = _select(
-        "Suite (which inspections to run):",
+        "Suite:",
         suite_names,
         default="core" if "core" in suite_names else suite_names[0],
         descriptions=suite_desc,
     )
 
+    # ── Step 5 · Mode ──────────────────────────────────────────────────
+    _step(5, "Mode", "How rigorous the run is.")
     mode = _select(
         "Run mode:",
         ["standard", "full"],
         default="standard",
         descriptions={
-            "standard": "CI-friendly; one judge auto-paired from your env.",
+            "standard": "CI-friendly; one judge (auto-paired from your env if none set above).",
             "full": "Reference-grade; needs a hand-built fixture and >=2 judges.",
         },
     )
-    if mode == "full" and len(judges) < 2:
+    # Full mode is unrunnable without >=2 judges — fix it here, not at run time.
+    while mode == "full" and len(judges) < 2:
         click.echo(
             click.style(
-                "  Note: --mode full needs >=2 judges; add a second or it is rejected at run time.",
+                f"  Full mode needs >=2 judges; you have {len(judges)}.",
                 fg="yellow",
             )
         )
+        choice = _select(
+            "How do you want to proceed?",
+            ["add a judge now", "switch to standard mode"],
+            default="add a judge now",
+        )
+        if choice == "switch to standard mode":
+            mode = "standard"
+        else:
+            judges.append(_add_judge(len(judges) + 1, provider, judge_candidates, available))
 
     # Leave eval_mode unset unless an ensemble is configured, so `run` picks the
     # best available mode (auto-pairing a judge from the environment) by default.
@@ -214,10 +302,25 @@ def setup() -> None:
         judges=judges,
     )
 
+    # ── Review ─────────────────────────────────────────────────────────
     click.echo()
-    click.echo(click.style("Your configuration:", bold=True))
-    click.echo(config.to_yaml())
+    click.echo(click.style("Review", bold=True))
+    target_kind = "agent" if is_agent else "model"
+    click.echo(f"  Target ({target_kind}):  {provider} / {model or '(provider default)'}"
+               + (f"  @ {endpoint}" if endpoint else ""))
+    if judges:
+        for i, j in enumerate(judges, 1):
+            click.echo(f"  Judge #{i}:       {j.provider} / {j.model or '(provider default)'}")
+    else:
+        click.echo("  Judge:          none")
+    click.echo(f"  Grade:          {_independence(judges, provider)}")
+    suite_count = next((r["count"] for r in suite_rows if str(r["name"]) == suite), "?")
+    click.echo(f"  Fixture:        {fixture}")
+    click.echo(f"  Suite:          {suite} ({suite_count} inspections)")
+    click.echo(f"  Mode:           {mode}")
+    click.echo(click.style("  Will run:       ifixai run   (SUT key entered at run time, never saved)", dim=True))
 
+    click.echo()
     if not click.confirm(f"Save to {CONFIG_FILENAME}?", default=True):
         click.echo("Aborted, nothing written.")
         return

--- a/ifixai/core/fixture_loader.py
+++ b/ifixai/core/fixture_loader.py
@@ -43,6 +43,10 @@ def resolve_fixture_path(name_or_path: str | Path) -> Path:
     if builtin_path.exists():
         return builtin_path
 
+    example_path = _FIXTURES_DIR / "examples" / f"{name_or_path}.yaml"
+    if example_path.exists():
+        return example_path
+
     raise FileNotFoundError(
         f"Fixture not found: '{name_or_path}'. "
         f"Provide a file path or a built-in name from: {list_fixture_names()}"
@@ -51,11 +55,16 @@ def resolve_fixture_path(name_or_path: str | Path) -> Path:
 def list_fixture_names() -> list[str]:
     if not _FIXTURES_DIR.exists():
         return []
-    return sorted(
+    builtin = {
         d.name
         for d in _FIXTURES_DIR.iterdir()
         if d.is_dir() and (d / "fixture.yaml").exists()
+    }
+    examples_dir = _FIXTURES_DIR / "examples"
+    examples = (
+        {p.stem for p in examples_dir.glob("*.yaml")} if examples_dir.is_dir() else set()
     )
+    return sorted(builtin | examples)
 
 def load_fixture(path: str | Path) -> Fixture:
     fixture_path = resolve_fixture_path(path)

--- a/ifixai/evaluation/analytic_judge.py
+++ b/ifixai/evaluation/analytic_judge.py
@@ -14,6 +14,7 @@ from json_repair import repair_json
 
 from ifixai.judge.evaluator import EnsembleJudgeEvaluator, JudgeEvaluator
 from ifixai.core.refusal import is_platform_refusal
+from ifixai.providers.base import is_fatal_provider_error
 from ifixai.core.types import (
     AnalyticRubric,
     ChatMessage,
@@ -834,6 +835,16 @@ class AnalyticRubricJudge:
                 )
             except Exception as exc:
                 last_exc = exc
+                if is_fatal_provider_error(exc):
+                    logger.error(
+                        "Judge call for %s aborted (non-retryable): %s",
+                        rubric.test_id,
+                        exc,
+                    )
+                    raise JudgeCommunicationError(
+                        f"Judge provider rejected the request (non-retryable): "
+                        f"{type(exc).__name__}: {exc}"
+                    ) from exc
                 if attempt < self._EXTRACTION_RETRIES:
                     logger.warning(
                         "Judge communication error for %s (attempt %d/%d), retrying — %s: %s",

--- a/ifixai/harness/suites.py
+++ b/ifixai/harness/suites.py
@@ -1,0 +1,156 @@
+"""Named test suites for the ``--suite`` selector (tiers and themes)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypedDict
+
+from ifixai.core.types import InspectionCategory
+
+_CORE_PILLARS: frozenset[InspectionCategory] = frozenset(
+    {
+        InspectionCategory.FABRICATION,
+        InspectionCategory.MANIPULATION,
+        InspectionCategory.DECEPTION,
+        InspectionCategory.UNPREDICTABILITY,
+        InspectionCategory.OPACITY,
+    }
+)
+
+
+class SuiteResolution(TypedDict):
+    test_ids: list[str]
+    unknown: list[str]
+
+
+def _core_ids() -> list[str]:
+    from ifixai.harness.registry import ALL_SPECS
+
+    return [s.test_id for s in ALL_SPECS if s.category in _CORE_PILLARS]
+
+
+def _extended_ids() -> list[str]:
+    from ifixai.harness.registry import ALL_SPECS
+
+    return [s.test_id for s in ALL_SPECS if s.category not in _CORE_PILLARS]
+
+
+def _all_ids() -> list[str]:
+    from ifixai.harness.registry import ALL_SPECS
+
+    return [s.test_id for s in ALL_SPECS]
+
+
+def _strategic_ids() -> list[str]:
+    from ifixai.harness.registry import STRATEGIC_TESTS
+
+    return list(STRATEGIC_TESTS)
+
+
+def _smoke_ids() -> list[str]:
+    return _strategic_ids()[:3]
+
+
+_TIER_RESOLVERS: dict[str, Callable[[], list[str]]] = {
+    "smoke": _smoke_ids,
+    "strategic": _strategic_ids,
+    "core": _core_ids,
+    "extended": _extended_ids,
+    "all": _all_ids,
+}
+
+_TIER_DESCRIPTIONS: dict[str, str] = {
+    "smoke": "Fastest sanity check (3 strategic inspections).",
+    "strategic": "The headline strategic set used for the strategic score.",
+    "core": "The 32 graded five-pillar inspections (B-series).",
+    "extended": "The 13 frontier inspections (P/C/S/X-series).",
+    "all": "Every registered inspection.",
+}
+
+
+class _Theme(TypedDict):
+    categories: list[str]
+    extra_ids: list[str]
+    description: str
+
+
+_THEMES: dict[str, _Theme] = {
+    "security": {
+        "categories": ["MANIPULATION"],
+        "extra_ids": ["P01", "P22", "P27", "P13"],
+        "description": "Injection, privilege escalation, sabotage, power elevation.",
+    },
+    "reliability": {
+        "categories": ["UNPREDICTABILITY"],
+        "extra_ids": ["B16", "B17", "B29", "B32", "C02", "C05", "C11"],
+        "description": "Consistency, reproducibility, silent failure, uncertainty calibration.",
+    },
+    "compliance": {
+        "categories": ["OPACITY"],
+        "extra_ids": ["B03", "B23", "P08", "X04", "X11"],
+        "description": "Auditability, traceability, regulatory readiness, oversight gates.",
+    },
+    "frontier": {
+        "categories": [],
+        "extra_ids": [],
+        "description": "The frontier / extended-risk roster (P/C/S/X-series).",
+    },
+}
+
+
+TIER_NAMES: list[str] = list(_TIER_RESOLVERS)
+THEME_NAMES: list[str] = list(_THEMES)
+SUITE_NAMES: list[str] = TIER_NAMES + THEME_NAMES
+
+
+def _dedup(ids: list[str]) -> list[str]:
+    from ifixai.harness.registry import ALL_SPECS
+
+    wanted = set(ids)
+    return [s.test_id for s in ALL_SPECS if s.test_id in wanted]
+
+
+def resolve_suite(name: str) -> SuiteResolution:
+    """Expand a suite name into its concrete, de-duplicated test IDs."""
+    from ifixai.harness.registry import resolve_category_test_ids
+
+    key = name.strip().lower()
+
+    if key in _TIER_RESOLVERS:
+        return {"test_ids": _dedup(_TIER_RESOLVERS[key]()), "unknown": []}
+
+    if key in _THEMES:
+        theme = _THEMES[key]
+        if key == "frontier":
+            return {"test_ids": _extended_ids(), "unknown": []}
+        from_categories = resolve_category_test_ids(theme["categories"])["test_ids"]
+        return {
+            "test_ids": _dedup([*from_categories, *theme["extra_ids"]]),
+            "unknown": [],
+        }
+
+    return {"test_ids": [], "unknown": [name]}
+
+
+def suite_catalog() -> list[dict[str, object]]:
+    """Rows for ``ifixai list suites``: name, kind, count, description."""
+    rows: list[dict[str, object]] = []
+    for tier in TIER_NAMES:
+        rows.append(
+            {
+                "name": tier,
+                "kind": "tier",
+                "count": len(resolve_suite(tier)["test_ids"]),
+                "description": _TIER_DESCRIPTIONS.get(tier, ""),
+            }
+        )
+    for theme in THEME_NAMES:
+        rows.append(
+            {
+                "name": theme,
+                "kind": "theme",
+                "count": len(resolve_suite(theme)["test_ids"]),
+                "description": _THEMES[theme]["description"],
+            }
+        )
+    return rows

--- a/ifixai/providers/base.py
+++ b/ifixai/providers/base.py
@@ -95,6 +95,78 @@ class ProviderResponseError(ProviderError):
     pass
 
 
+_FATAL_ERROR_MARKERS: tuple[str, ...] = (
+    "401",
+    "403",
+    "invalid api key",
+    "invalid_api_key",
+    "incorrect api key",
+    "unauthorized",
+    "permission denied",
+    "permissiondenied",
+    "authentication",
+    "limit exceeded",
+    "quota",
+    "insufficient_quota",
+    "billing",
+    "payment required",
+    "credit",
+)
+
+
+def is_fatal_provider_error(exc: BaseException) -> bool:
+    """True when an error means the credential is rejected / out of quota."""
+    if isinstance(exc, ProviderAuthError):
+        return True
+    text = str(exc).lower()
+    # Rate limits (HTTP 429) are transient — the retry loop backs off and
+    # recovers — so they are never fatal, even though a "rate limit exceeded"
+    # string contains the "limit exceeded" fatal marker.
+    if (
+        isinstance(exc, ProviderRateLimitError)
+        or "rate limit" in text
+        or "rate_limit" in text
+        or "429" in text
+        or "too many requests" in text
+    ):
+        return False
+    return any(marker in text for marker in _FATAL_ERROR_MARKERS)
+
+
+def friendly_provider_message(detail: str) -> str | None:
+    """Map a raw provider error string to one actionable sentence, or None."""
+    low = detail.lower()
+    if "limit exceeded" in low or "quota" in low or "insufficient_quota" in low:
+        return (
+            "API key is out of quota / hit its usage limit. "
+            "Top it up, raise the limit, or use a different key."
+        )
+    if (
+        "401" in low
+        or "invalid api key" in low
+        or "incorrect api key" in low
+        or "unauthorized" in low
+        or "authentication" in low
+    ):
+        return (
+            "API key was rejected (authentication failed). "
+            "Check the key value and that it matches the chosen provider."
+        )
+    if "403" in low or "permission" in low or "forbidden" in low:
+        return (
+            "Access was forbidden (403). The key may lack permission for this "
+            "model, or have exceeded a usage/billing limit."
+        )
+    if "429" in low or "rate limit" in low or "rate_limit" in low:
+        return (
+            "Rate limited by the provider. Lower --concurrency or wait a moment "
+            "and retry."
+        )
+    if "billing" in low or "payment" in low or "credit" in low:
+        return "Provider reports a billing/credit problem on the account."
+    return None
+
+
 class ProviderEmptyContentError(ProviderResponseError):
     """Provider returned a successful response with no text content.
 

--- a/ifixai/reporting/scorecard.py
+++ b/ifixai/reporting/scorecard.py
@@ -35,6 +35,94 @@ B22_SKIPPED_MESSAGE: Final[str] = (
 SEED_UNSUPPORTED_PREFIX: Final[str] = "b12 seed accepted but provider cannot honour: "
 
 
+def compute_insights(result: TestRunResult) -> dict[str, object]:
+    """Derive presentation-ready insights shared by console and file reports."""
+    results = result.test_results
+
+    status_counts = {"pass": 0, "fail": 0, "inconclusive": 0, "error": 0}
+    for br in results:
+        status_counts[br.status.value] = status_counts.get(br.status.value, 0) + 1
+
+    scored = [
+        (cs.category.value, cs.score)
+        for cs in result.category_scores
+        if cs.score is not None
+    ]
+    weakest = sorted(scored, key=lambda pair: pair[1])[:3]
+
+    total_categories = len(result.category_scores)
+    scored_categories = len(scored)
+
+    exploratory = [
+        {
+            "test_id": br.test_id,
+            "name": br.name,
+            "score": br.score,
+            "passing": br.passing,
+        }
+        for br in results
+        if br.spec is not None and br.spec.is_exploratory
+    ]
+
+    delta = None
+    if (
+        not result.self_judged
+        and result.overall_score is not None
+        and result.strategic_score is not None
+    ):
+        delta = result.overall_score - result.strategic_score
+
+    return {
+        "self_judged": result.self_judged,
+        "status_counts": status_counts,
+        "total_tests": len(results),
+        "weakest_pillars": weakest,
+        "scored_categories": scored_categories,
+        "total_categories": total_categories,
+        "exploratory": exploratory,
+        "overall_score": result.overall_score,
+        "strategic_score": result.strategic_score,
+        "grade": result.grade.value,
+        "strategic_overall_delta": delta,
+        "passed": result.passed,
+    }
+
+
+def render_insights(result: TestRunResult) -> str:
+    """Markdown "Insights" section derived from :func:`compute_insights`."""
+    ins = compute_insights(result)
+    sc = ins["status_counts"]
+    lines = ["## Insights", ""]
+    lines.append(
+        f"- **Tests:** {sc['pass']} passed · {sc['fail']} failed · "
+        f"{sc['inconclusive']} inconclusive"
+        + (f" · {sc['error']} error" if sc["error"] else "")
+    )
+    lines.append(
+        f"- **Category coverage:** {ins['scored_categories']}/"
+        f"{ins['total_categories']} categories scored"
+    )
+    if not ins["self_judged"] and ins["weakest_pillars"]:
+        weakest = ", ".join(
+            f"{name} ({score:.0%})" for name, score in ins["weakest_pillars"]
+        )
+        lines.append(f"- **Weakest pillars:** {weakest}")
+    if not ins["self_judged"] and ins["strategic_overall_delta"] is not None:
+        delta = ins["strategic_overall_delta"]
+        sign = "+" if delta >= 0 else ""
+        lines.append(
+            f"- **Overall vs strategic:** {ins['overall_score']:.1%} overall "
+            f"vs {ins['strategic_score']:.1%} strategic ({sign}{delta:.1%})"
+        )
+    if ins["exploratory"]:
+        names = ", ".join(item["test_id"] for item in ins["exploratory"])
+        lines.append(
+            f"- **Exploratory (not scored):** {len(ins['exploratory'])} "
+            f"inspection(s) — {names}"
+        )
+    return "\n".join(lines)
+
+
 def insufficient_evidence_warnings(
     test_results: list[TestResult],
 ) -> list[str]:
@@ -182,6 +270,7 @@ def generate_json_report(result: TestRunResult) -> str:
         "mandatory_minimums": build_mandatory_minimums_section(result),
         "test_results": build_test_results_section(result, frameworks),
         "regulatory": build_regulatory_json_section(result, frameworks),
+        "insights": compute_insights(result),
     }
 
     return json.dumps(report, indent=2, ensure_ascii=False)
@@ -193,6 +282,7 @@ def generate_markdown_report(result: TestRunResult) -> str:
     sections = [
         render_header(result),
         render_summary(result),
+        render_insights(result),
         render_category_table(result),
         render_mandatory_minimums(result),
         render_consistency_warnings(result),
@@ -205,6 +295,44 @@ def generate_markdown_report(result: TestRunResult) -> str:
         render_footer(result),
     ]
 
+    return "\n\n".join(s for s in sections if s) + "\n"
+
+
+def _render_top_failures(result: TestRunResult, limit: int = 8) -> str:
+    """A compact 'where it hurts most' list — lowest-scoring failed inspections."""
+    failed = [
+        br
+        for br in result.test_results
+        if br.status == TestStatus.FAIL and not br.insufficient_evidence
+    ]
+    if not failed:
+        return ""
+    failed.sort(key=lambda br: br.score)
+    lines = ["## Top failures", ""]
+    for br in failed[:limit]:
+        name = br.name or br.test_id
+        lines.append(
+            f"- **{br.test_id}** {name} — {br.score:.0%} "
+            f"(threshold {br.threshold:.0%}, {br.category.value})"
+        )
+    remaining = len(failed) - limit
+    if remaining > 0:
+        lines.append(f"- …and {remaining} more (see the full report).")
+    return "\n".join(lines)
+
+
+def generate_summary_report(result: TestRunResult) -> str:
+    """Short scannable report: headline, insights, categories, top failures."""
+    sections = [
+        render_header(result),
+        render_summary(result),
+        render_insights(result),
+        render_category_table(result),
+        render_mandatory_minimums(result),
+        _render_top_failures(result),
+        "_This is the summary. The full report (with per-inspection evidence) "
+        "is the companion `.md` without the `-summary` suffix._",
+    ]
     return "\n\n".join(s for s in sections if s) + "\n"
 
 


### PR DESCRIPTION
Update — current state:

Curated the valuable half of https://github.com/ifixai-ai/iFixAi/pull/44 onto main: --suite selector + list suites/list categories, scorecard insights + -summary.md digest, friendly auth/quota errors. Dropped rich/questionary deps and the key-storing ifixai.yaml.
Added a guided ifixai setup wizard (click-only, no new deps): model-or-agent aware, guards against a non-independent judge and unrunnable full mode; SUT key is never stored.
CLI polish: shows the uncapped score (capped from X%), states each provider's real default model, and saves config without ever blocking the run.