### PR TITLE
Crash resilience for paid runs

### DIFF
--- a/ifixai/api.py
+++ b/ifixai/api.py
@@ -131,6 +131,7 @@ async def run_inspections(
     holdout_ids: dict[str, str] | None = None,
     auth_method: str = "bearer",
     extra_headers: dict[str, str] | None = None,
+    cached_results: dict[str, TestResult] | None = None,
 ) ->TestRunResult:
     fixture_obj = _resolve_fixture(fixture)
     provider_obj = _resolve_provider_with_governance(provider, fixture_obj)
@@ -159,6 +160,7 @@ async def run_inspections(
             judge_config=judge_config,
             pipeline_config=pipeline_config,
             governor=governor,
+            cached_results=cached_results,
         )
     finally:
         await _aclose_provider(provider_obj)
@@ -185,6 +187,7 @@ async def run_strategic(
     holdout_ids: dict[str, str] | None = None,
     auth_method: str = "bearer",
     extra_headers: dict[str, str] | None = None,
+    cached_results: dict[str, TestResult] | None = None,
 ) ->TestRunResult:
     fixture_obj = _resolve_fixture(fixture)
     provider_obj = _resolve_provider_with_governance(provider, fixture_obj)
@@ -213,6 +216,7 @@ async def run_strategic(
             judge_config=judge_config,
             pipeline_config=pipeline_config,
             governor=governor,
+            cached_results=cached_results,
         )
     finally:
         await _aclose_provider(provider_obj)
@@ -240,6 +244,7 @@ async def run_selected(
     holdout_ids: dict[str, str] | None = None,
     auth_method: str = "bearer",
     extra_headers: dict[str, str] | None = None,
+    cached_results: dict[str, TestResult] | None = None,
 ) ->TestRunResult:
     fixture_obj = _resolve_fixture(fixture)
     provider_obj = _resolve_provider_with_governance(provider, fixture_obj)
@@ -269,6 +274,7 @@ async def run_selected(
             judge_config=judge_config,
             pipeline_config=pipeline_config,
             governor=governor,
+            cached_results=cached_results,
         )
     finally:
         await _aclose_provider(provider_obj)

--- a/ifixai/cli/orchestrator.py
+++ b/ifixai/cli/orchestrator.py
@@ -1,7 +1,9 @@
 import io
+import logging
 import os
 import sys
 import threading
+from pathlib import Path
 
 import click
 
@@ -9,6 +11,7 @@ from ifixai.api import run_inspections, run_selected, run_single, run_strategic
 from ifixai.cli.schemas import EvalModeResolution
 from ifixai.core.concurrency import ConcurrencyGovernor
 from ifixai.core.fixture_loader import load_fixture
+from ifixai.core.runner import build_partial_result
 from ifixai.core.types import (
     EvaluationPipelineConfig,
     InspectionCategory,
@@ -16,6 +19,7 @@ from ifixai.core.types import (
     TestRunResult,
     TestStatus,
 )
+from ifixai.evaluation.checkpoint import save_checkpoint
 from ifixai.evaluation.errors import JudgeUnavailableError
 from ifixai.harness.registry import ALL_SPECS, SPEC_BY_ID
 from ifixai.judge.config import JudgeConfig, JudgeProviderSpec
@@ -25,6 +29,8 @@ from ifixai.providers.resolver import (
     select_cross_provider_judge,
 )
 from ifixai.scoring.category_weights import STRATEGIC_TEST_IDS
+
+_logger = logging.getLogger(__name__)
 
 
 def _enable_windows_vt_processing() -> bool:
@@ -507,6 +513,9 @@ async def execute_tests(
     holdout_ids: dict[str, str] | None = None,
     auth_method: str = "bearer",
     extra_headers: dict[str, str] | None = None,
+    checkpoint_dir: Path | None = None,
+    checkpoint_run_id: str | None = None,
+    cached_results: dict[str, TestResult] | None = None,
 ) -> TestRunResult | None:
 
     try:
@@ -514,6 +523,12 @@ async def execute_tests(
     except FileNotFoundError as exc:
         click.echo(click.style(f"Fixture error: {exc}", fg="red"))
         return None
+
+    # Crash resilience: every completed inspection is checkpointed to disk the
+    # moment it lands, so an abort (judge down, quota exhausted, Ctrl-C, crash)
+    # loses at most the in-flight inspection instead of the whole paid run.
+    # `completed` also feeds the partial scorecard written on abort.
+    completed: dict[str, TestResult] = dict(cached_results or {})
 
     # Animated in-place display needs ANSI cursor escapes. On Windows,
     # those are inert unless VT processing is enabled on the console
@@ -531,11 +546,63 @@ async def execute_tests(
         display = BenchmarkProgressDisplay(_build_display_tests(strategic, test_ids))
         display.start()
         effective_callback = display.update
+        for cached_id, cached_result in completed.items():
+            display.update(cached_id, 0, 0, cached_result)
     else:
         effective_callback = progress_callback or _progress_callback_plain
+        for cached_id in sorted(completed):
+            click.echo(f"  [reused] {cached_id} ... from checkpoint")
+
+    inner_callback = effective_callback
+
+    def _checkpointing_callback(
+        test_id: str, index: int, total: int, result: TestResult
+    ) -> None:
+        completed[test_id] = result
+        if checkpoint_dir is not None and checkpoint_run_id is not None:
+            try:
+                save_checkpoint(checkpoint_dir, checkpoint_run_id, completed)
+            except Exception:  # a checkpoint hiccup must never abort the run it protects
+                _logger.exception("Checkpoint write failed; continuing the run")
+        inner_callback(test_id, index, total, result)
+
+    effective_callback = _checkpointing_callback
+
+    def _partial_result(abort_reason: str) -> TestRunResult | None:
+        """Salvage a scorecard from `completed` when the run aborts; None if
+        nothing finished (there is nothing to save)."""
+        if not completed:
+            return None
+        planned = [tid for tid, _ in _build_display_tests(strategic, test_ids)]
+        if test_ids:
+            partial_mode = "selected"
+        elif strategic:
+            partial_mode = "strategic"
+        else:
+            partial_mode = "full"
+        try:
+            partial = build_partial_result(
+                completed=list(completed.values()),
+                planned_ids=planned,
+                abort_reason=abort_reason,
+                system_name=system_name or provider,
+                system_version=system_version,
+                fixture_name=loaded_fixture.metadata.name,
+                provider_name=provider,
+                run_mode=partial_mode,
+                sut_temperature=sut_temperature,
+                sut_seed=sut_seed,
+            )
+        except Exception:
+            # The checkpoint on disk still has every completed result; a
+            # scoring failure here must not also erase the abort message.
+            _logger.exception("Could not build the partial scorecard")
+            return None
+        partial.self_judged = self_judged
+        return partial
 
     try:
-        if len(test_ids) == 1:
+        if len(test_ids) == 1 and not completed:
             test_id = test_ids[0]
             single_result = await run_single(
                 test_id=test_id,
@@ -578,7 +645,9 @@ async def execute_tests(
                 run_mode="single",
             )
 
-        if len(test_ids) >= 2:
+        # A single test with a checkpointed result also routes through
+        # run_selected, which knows how to reuse cached results.
+        if test_ids:
             selected_result = await run_selected(
                 test_ids={tid.upper() for tid in test_ids},
                 provider=provider,
@@ -600,6 +669,7 @@ async def execute_tests(
                 holdout_ids=holdout_ids,
                 auth_method=auth_method,
                 extra_headers=extra_headers,
+                cached_results=cached_results,
             )
             selected_result.self_judged = self_judged
             return selected_result
@@ -625,6 +695,7 @@ async def execute_tests(
                 holdout_ids=holdout_ids,
                 auth_method=auth_method,
                 extra_headers=extra_headers,
+                cached_results=cached_results,
             )
             strategic_result.self_judged = self_judged
             return strategic_result
@@ -649,6 +720,7 @@ async def execute_tests(
             holdout_ids=holdout_ids,
             auth_method=auth_method,
             extra_headers=extra_headers,
+            cached_results=cached_results,
         )
 
     except JudgeUnavailableError as exc:
@@ -662,10 +734,10 @@ async def execute_tests(
         click.echo(
             click.style(f"\n*** RUN STOPPED *** {exc.detail}", fg="red"), err=True
         )
-        return None
+        return _partial_result(exc.detail)
     except Exception as exc:  # noqa: BLE001 — top-level run guard; report any failure to the user
         click.echo(click.style(f"Test execution failed: {exc}", fg="red"))
-        return None
+        return _partial_result(str(exc))
 
     else:
         inspections_result.self_judged = self_judged

--- a/ifixai/cli/run.py
+++ b/ifixai/cli/run.py
@@ -54,22 +54,27 @@ from ifixai.core.types import (
     EvaluationPipelineConfig,
     ProviderConfig,
     RunMode,
+    TestResult,
 )
+from ifixai.evaluation.checkpoint import load_checkpoint
 from ifixai.evaluation.manifest import (
+    RunManifest,
     build_manifest,
     generate_run_nonce,
     is_valid_run_nonce,
+    load_manifest,
     write_manifest,
 )
 from ifixai.evaluation.normalizer import NORMALIZER_VERSION
 from ifixai.evaluation.types import ModelDescriptor
 from ifixai.harness.registry import (
+    ALL_SPECS,
     CATEGORY_NAMES,
     SPEC_BY_ID,
     resolve_category_test_ids,
 )
 from ifixai.harness.suites import SUITE_NAMES, resolve_suite
-from ifixai.inspections.holdout_ids import generate_holdout_ids
+from ifixai.inspections.holdout_ids import HoldoutIds, generate_holdout_ids
 from ifixai.providers.base import ChatProvider
 from ifixai.providers.governance_fixture import GovernanceFixture
 from ifixai.providers.resolver import (
@@ -92,6 +97,7 @@ from ifixai.reporting.health import (
     measurement_failure_banner,
     run_health,
 )
+from ifixai.scoring.category_weights import STRATEGIC_TEST_IDS
 from ifixai.utils.fixture_digest import compute_fixture_digest
 from ifixai.utils.rubric_digest import compute_rubric_digests_for_tests_layout
 from ifixai.wizard import generate_fixture_from_wizard, run_wizard
@@ -137,6 +143,24 @@ PROVIDER_CHOICES = [
 ]
 
 FORMAT_CHOICES = ["json", "markdown", "both"]
+
+
+def _judge_bias_class(eval_mode: str) -> str:
+    """'self', 'none' (deterministic-only), or 'external' — the grading
+    property that must stay constant across resumed sessions."""
+    if eval_mode == "self":
+        return "self"
+    if eval_mode == "deterministic":
+        return "none"
+    return "external"
+
+
+def _manifest_diff(previous: RunManifest, current: RunManifest) -> list[str]:
+    """Names of the manifest fields whose values differ (identity fields only)."""
+    exclude = {"run_id", "timestamp"}
+    prev = previous.model_dump(mode="json", exclude=exclude)
+    cur = current.model_dump(mode="json", exclude=exclude)
+    return sorted(k for k in prev.keys() | cur.keys() if prev.get(k) != cur.get(k))
 
 
 def _resolve_concurrency(flag_value: int | None, no_parallel: bool) -> int:
@@ -525,6 +549,15 @@ def _print_concurrency_banner(resolved: int) -> None:
     "one subdirectory per run_id.",
 )
 @click.option(
+    "--resume",
+    "resume_run_id",
+    default=None,
+    help="Resume an interrupted run by its run ID (printed at run start; the "
+    "directory name under --reliability-out). Completed inspections are "
+    "restored from the run's checkpoint and only the remaining ones execute. "
+    "Requires the same flags/config as the original run.",
+)
+@click.option(
     "--dry-run",
     is_flag=True,
     default=False,
@@ -717,6 +750,7 @@ def run(
     profile: str,
     run_mode: str | None,
     reliability_out: str,
+    resume_run_id: str | None,
     dry_run: bool,
     judge_budget: int,
     concurrency: int | None,
@@ -824,6 +858,49 @@ def run(
     b30_seed_pinned = b30_seed is not None
     b29_seed_pinned = b29_seed is not None
     b32_seed_pinned = b32_seed is not None
+
+    # --resume: reuse the original run's per-run random values (nonce, corpus
+    # seeds, holdout ids) so the manifest rebuilt below hashes to the same
+    # run_id. Everything the user chose (model, fixture, judges, selection)
+    # must be re-passed identically; the identity check at manifest time
+    # refuses to resume when it differs.
+    resume_manifest = None
+    if resume_run_id:
+        manifest_file = Path(reliability_out) / resume_run_id / "manifest.json"
+        if not manifest_file.exists():
+            click.echo(
+                click.style(
+                    f"Error: --resume {resume_run_id}: no manifest at "
+                    f"{manifest_file}. Check the run ID and --reliability-out.",
+                    fg="red",
+                ),
+                err=True,
+            )
+            sys.exit(1)
+        resume_manifest = load_manifest(manifest_file)
+        if run_nonce is not None and run_nonce != resume_manifest.run_nonce:
+            click.echo(
+                click.style(
+                    "--run-nonce is ignored with --resume; reusing the "
+                    "original run's nonce.",
+                    fg="yellow",
+                ),
+                err=True,
+            )
+        effective_run_nonce = resume_manifest.run_nonce
+        effective_b12_seed = resume_manifest.b12_seed
+        effective_b14_seed = resume_manifest.b14_seed
+        effective_b28_seed = resume_manifest.b28_seed
+        effective_b30_seed = resume_manifest.b30_seed
+        effective_b29_seed = resume_manifest.b29_seed
+        effective_b32_seed = resume_manifest.b32_seed
+        b12_seed_pinned = resume_manifest.b12_seed_pinned
+        b14_seed_pinned = resume_manifest.b14_seed_pinned
+        b28_seed_pinned = resume_manifest.b28_seed_pinned
+        b30_seed_pinned = resume_manifest.b30_seed_pinned
+        b29_seed_pinned = resume_manifest.b29_seed_pinned
+        b32_seed_pinned = resume_manifest.b32_seed_pinned
+        holdout_seed = resume_manifest.holdout_seed
 
     print_startup_banner(IFIXAI_VERSION, quiet=quiet)
     if no_telemetry:
@@ -1098,7 +1175,22 @@ def run(
                 fg="cyan",
             )
         )
-    holdout = generate_holdout_ids(holdout_seed)
+    if resume_manifest is not None and resume_manifest.holdout_ids:
+        try:
+            holdout = HoldoutIds(**resume_manifest.holdout_ids)
+        except TypeError:
+            # Manifest written by a version with a different holdout shape.
+            click.echo(
+                click.style(
+                    f"Error: cannot resume {resume_run_id}: its holdout ids "
+                    "don't match this ifixai version. Start a fresh run.",
+                    fg="red",
+                ),
+                err=True,
+            )
+            sys.exit(1)
+    else:
+        holdout = generate_holdout_ids(holdout_seed)
     test_config = ProviderConfig(
         provider=provider,
         endpoint=endpoint,
@@ -1444,36 +1536,230 @@ def run(
         f"Grounding: {_GROUNDING_LABEL.get(grounding_mode, grounding_mode.value)}"
     )
 
+    # The manifest is built and written BEFORE the run: its run_id keys the
+    # per-inspection checkpoint, so a run that dies mid-way (judge quota,
+    # crash, Ctrl-C) can be resumed with --resume instead of repaying for
+    # completed inspections. test_versions comes from the planned selection,
+    # which for a completed run is identical to what the results would yield.
+    if test:
+        planned_ids = [tid.upper() for tid in test]
+    elif strategic:
+        strategic_set = set(STRATEGIC_TEST_IDS)
+        planned_ids = [s.test_id for s in ALL_SPECS if s.test_id in strategic_set]
+    else:
+        planned_ids = [s.test_id for s in ALL_SPECS]
+    test_versions = {}
+    for tid in planned_ids:
+        spec = SPEC_BY_ID.get(tid)
+        test_versions[tid] = spec.version if spec is not None else "1.0.0"
+
+    manifest_mode = RunMode.FULL if profile.lower() == "full" else RunMode.STANDARD
+    model_descriptor = ModelDescriptor(
+        provider=provider or "unknown",
+        model_id=model or "unknown",
+        version=system_version,
+        family=provider or None,
+    )
+    resolved_fixture_path = resolve_fixture_path(fixture)
+    judge_identity_descriptor: ModelDescriptor | None = None
+    if eval_mode_auto_selected_judge is not None:
+        judge_identity_descriptor = ModelDescriptor(
+            provider=eval_mode_auto_selected_judge,
+            model_id=(
+                judge_model[-1]
+                if judge_model
+                else f"{eval_mode_auto_selected_judge}-default"
+            ),
+            version="auto-paired",
+            family=eval_mode_auto_selected_judge,
+        )
+    governance_fixture_digest_value: str | None = None
+    if governance_path is not None:
+        governance_fixture_digest_value = compute_fixture_digest(governance_path)
+
+    manifest = build_manifest(
+        mode=manifest_mode,
+        model_under_test=model_descriptor,
+        judge_models=[],
+        normalizer_version=NORMALIZER_VERSION,
+        test_versions=test_versions,
+        rubric_hashes=compute_rubric_digests_for_tests_layout(_TESTS_DIR),
+        fixture_digest=compute_fixture_digest(resolved_fixture_path),
+        governance_fixture_digest=governance_fixture_digest_value,
+        governance_source=governance_source,
+        mode_filter=(list(test) if test else (["strategic"] if strategic else ["all"])),
+        judge_identity=judge_identity_descriptor,
+        b12_seed=effective_b12_seed,
+        b14_seed=effective_b14_seed,
+        b28_seed=effective_b28_seed,
+        b30_seed=effective_b30_seed,
+        b12_seed_pinned=b12_seed_pinned,
+        b14_seed_pinned=b14_seed_pinned,
+        b28_seed_pinned=b28_seed_pinned,
+        b30_seed_pinned=b30_seed_pinned,
+        b29_seed=effective_b29_seed,
+        b32_seed=effective_b32_seed,
+        b29_seed_pinned=b29_seed_pinned,
+        b32_seed_pinned=b32_seed_pinned,
+        holdout_seed=holdout_seed,
+        holdout_ids=holdout.to_dict(),
+        run_nonce=effective_run_nonce,
+    )
+
+    if resume_manifest is not None and manifest.run_id != resume_manifest.run_id:
+        changed = _manifest_diff(resume_manifest, manifest)
+        click.echo(
+            click.style(
+                f"Error: cannot resume {resume_run_id}: the run configuration "
+                f"changed since that run (differs in: {', '.join(changed) or 'unknown fields'}). "
+                "A resumed run must use the same model, fixture, judges, "
+                "selection and seeds. Start a fresh run instead.",
+                fg="red",
+            ),
+            err=True,
+        )
+        sys.exit(1)
+
+    # The judge's bias class (self / external / none) must not change across
+    # sessions: a resumed scorecard mixing self-judged and cross-judged results
+    # would carry the final session's honesty banners only. Swapping the judge
+    # MODEL within the same class is allowed (that's the escape hatch for a
+    # dead judge) — reused results keep their original grading, disclosed in
+    # the scorecard.
+    session_file = Path(reliability_out) / manifest.run_id / "session.json"
+    bias_class = _judge_bias_class(eval_mode)
+    if resume_manifest is not None and session_file.exists():
+        try:
+            prior_session = json.loads(session_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            prior_session = {}
+        prior_class = prior_session.get("judge_bias_class")
+        if prior_class is not None and prior_class != bias_class:
+            click.echo(
+                click.style(
+                    f"Error: cannot resume {resume_run_id}: the original run "
+                    f"was graded '{prior_class}' but this session would grade "
+                    f"'{bias_class}'. Mixing self-judged and independently "
+                    "judged results in one scorecard is not allowed. Rerun "
+                    "with the original evaluation mode, or start a fresh run.",
+                    fg="red",
+                ),
+                err=True,
+            )
+            sys.exit(1)
+        prior_judge = prior_session.get("judge")
+        if prior_judge is not None and prior_judge != judge_label:
+            click.echo(
+                click.style(
+                    f"Judge changed since the original session (was "
+                    f"{prior_judge}, now {judge_label}); reused results keep "
+                    "the original judge's grading.",
+                    fg="yellow",
+                )
+            )
+
+    manifest_path = write_manifest(manifest, Path(reliability_out))
+    session_file.write_text(
+        json.dumps({"judge_bias_class": bias_class, "judge": judge_label}),
+        encoding="utf-8",
+    )
+    click.echo(
+        f"Run ID: {manifest.run_id}  "
+        f"(if interrupted, resume with --resume {manifest.run_id})"
+    )
+
+    cached_results: dict[str, TestResult] = {}
+    if resume_manifest is not None:
+        planned_set = set(planned_ids)
+        cached_results = {
+            tid: res
+            for tid, res in load_checkpoint(
+                Path(reliability_out), manifest.run_id
+            ).items()
+            if tid in planned_set
+        }
+        click.echo(
+            click.style(
+                f"Resuming: {len(cached_results)} of {len(planned_ids)} "
+                f"inspections restored from checkpoint; running the remaining "
+                f"{len(planned_ids) - len(cached_results)}.",
+                fg="cyan",
+            )
+        )
+
     if sys.platform == "win32":
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-    result = asyncio.run(
-        execute_tests(
-            provider=provider,
-            api_key=api_key,
-            fixture=fixture,
-            endpoint=endpoint,
-            auth_method=auth_method,
-            extra_headers=extra_headers_dict,
-            model=model,
-            system_prompt=effective_system_prompt,
-            strategic=strategic,
-            test_ids=test,
-            timeout=timeout,
-            system_name=resolved_name,
-            system_version=system_version,
-            pipeline_config=pipeline_config,
-            judge_config=judge_config,
-            governor=concurrency_governor,
-            sut_temperature=sut_temperature,
-            sut_seed=sut_seed,
-            run_nonce=effective_run_nonce,
-            self_judged=(eval_mode == "self"),
-            holdout_ids=holdout.to_dict(),
+    try:
+        result = asyncio.run(
+            execute_tests(
+                provider=provider,
+                api_key=api_key,
+                fixture=fixture,
+                endpoint=endpoint,
+                auth_method=auth_method,
+                extra_headers=extra_headers_dict,
+                model=model,
+                system_prompt=effective_system_prompt,
+                strategic=strategic,
+                test_ids=test,
+                timeout=timeout,
+                system_name=resolved_name,
+                system_version=system_version,
+                pipeline_config=pipeline_config,
+                judge_config=judge_config,
+                governor=concurrency_governor,
+                sut_temperature=sut_temperature,
+                sut_seed=sut_seed,
+                run_nonce=effective_run_nonce,
+                self_judged=(eval_mode == "self"),
+                holdout_ids=holdout.to_dict(),
+                checkpoint_dir=Path(reliability_out),
+                checkpoint_run_id=manifest.run_id,
+                cached_results=cached_results,
+            )
         )
-    )
+    except KeyboardInterrupt:
+        click.echo()
+        click.echo(
+            click.style(
+                "Interrupted. Completed inspections are checkpointed; rerun "
+                f"with the same flags plus --resume {manifest.run_id} to finish "
+                "without repeating them.",
+                fg="yellow",
+            ),
+            err=True,
+        )
+        sys.exit(130)
 
     if result is None:
         sys.exit(1)
+
+    if result.partial:
+        click.echo()
+        click.echo(
+            click.style(
+                f"*** PARTIAL RESULTS *** run aborted: {result.abort_reason}",
+                fg="red",
+                bold=True,
+            )
+        )
+        click.echo(
+            click.style(
+                f"Writing a scorecard for the {len(result.test_results)} "
+                f"completed inspection(s). Run the rest with "
+                f"--resume {manifest.run_id}.",
+                fg="yellow",
+            )
+        )
+    if cached_results:
+        result.resumed_run_id = manifest.run_id
+        result.reused_result_count = len(cached_results)
+        result.warnings.append(
+            f"Resumed run {manifest.run_id}: {len(cached_results)} of "
+            f"{len(planned_ids)} inspection results reused from a previous "
+            "session. Judge-call stats cover only this session; reused "
+            "results keep the grading of the judge that originally ran them."
+        )
 
     governance_warning = _governance_source_warning(governance_source)
     if governance_warning is not None and governance_warning not in result.warnings:
@@ -1605,64 +1891,6 @@ def run(
         )
         click.echo(f"  Interactive artifact -> {artifact_out}")
 
-    run_mode = RunMode.FULL if profile.lower() == "full" else RunMode.STANDARD
-    model_descriptor = ModelDescriptor(
-        provider=provider or "unknown",
-        model_id=model or "unknown",
-        version=system_version,
-        family=provider or None,
-    )
-    test_versions = {}
-    for br in result.test_results:
-        bare_id = br.test_id.replace("SSCI-", "")
-        spec = SPEC_BY_ID.get(bare_id)
-        test_versions[bare_id] = spec.version if spec is not None else "1.0.0"
-    resolved_fixture_path = resolve_fixture_path(fixture)
-    judge_identity_descriptor: ModelDescriptor | None = None
-    if eval_mode_auto_selected_judge is not None:
-        judge_identity_descriptor = ModelDescriptor(
-            provider=eval_mode_auto_selected_judge,
-            model_id=(
-                judge_model[-1]
-                if judge_model
-                else f"{eval_mode_auto_selected_judge}-default"
-            ),
-            version="auto-paired",
-            family=eval_mode_auto_selected_judge,
-        )
-    governance_fixture_digest_value: str | None = None
-    if governance_path is not None:
-        governance_fixture_digest_value = compute_fixture_digest(governance_path)
-
-    manifest = build_manifest(
-        mode=run_mode,
-        model_under_test=model_descriptor,
-        judge_models=[],
-        normalizer_version=NORMALIZER_VERSION,
-        test_versions=test_versions,
-        rubric_hashes=compute_rubric_digests_for_tests_layout(_TESTS_DIR),
-        fixture_digest=compute_fixture_digest(resolved_fixture_path),
-        governance_fixture_digest=governance_fixture_digest_value,
-        governance_source=governance_source,
-        mode_filter=(list(test) if test else (["strategic"] if strategic else ["all"])),
-        judge_identity=judge_identity_descriptor,
-        b12_seed=effective_b12_seed,
-        b14_seed=effective_b14_seed,
-        b28_seed=effective_b28_seed,
-        b30_seed=effective_b30_seed,
-        b12_seed_pinned=b12_seed_pinned,
-        b14_seed_pinned=b14_seed_pinned,
-        b28_seed_pinned=b28_seed_pinned,
-        b30_seed_pinned=b30_seed_pinned,
-        b29_seed=effective_b29_seed,
-        b32_seed=effective_b32_seed,
-        b29_seed_pinned=b29_seed_pinned,
-        b32_seed_pinned=b32_seed_pinned,
-        holdout_seed=holdout_seed,
-        holdout_ids=holdout.to_dict(),
-        run_nonce=effective_run_nonce,
-    )
-    manifest_path = write_manifest(manifest, Path(reliability_out))
     click.echo()
     click.echo(click.style("Run manifest", bold=True))
     click.echo(f"  Mode:     {manifest.mode.value}")
@@ -1671,6 +1899,11 @@ def run(
     click.echo(f"  Manifest: {manifest_path}")
 
     telemetry.emit_completed()
+
+    if result.partial:
+        # Reports and checkpoint are on disk; a partial run still exits
+        # non-zero so CI can never mistake it for a full result.
+        sys.exit(1)
 
     if result.overall_score is None:
         click.echo(

--- a/ifixai/core/runner.py
+++ b/ifixai/core/runner.py
@@ -399,6 +399,21 @@ def _merge_cached(
     return sorted([*reused_results, *fresh_results], key=lambda r: r.test_id)
 
 
+_ABORT_REASON_MAX_LEN = 160
+
+
+def _summarize_abort_reason(reason: str) -> str:
+    """First line of the abort reason, capped for reports.
+
+    The full provider error (raw response bodies, account ids) belongs on the
+    console at abort time, not persisted verbatim into shareable scorecards.
+    """
+    first_line = reason.strip().splitlines()[0] if reason.strip() else "unknown"
+    if len(first_line) <= _ABORT_REASON_MAX_LEN:
+        return first_line
+    return first_line[: _ABORT_REASON_MAX_LEN - 1] + "…"
+
+
 def build_partial_result(
     completed: list[TestResult],
     planned_ids: list[str],
@@ -417,6 +432,7 @@ def build_partial_result(
     unevaluated gate failures, and the warning below says exactly what did
     not run. The point is to not discard paid-for results on abort.
     """
+    abort_reason = _summarize_abort_reason(abort_reason)
     result = _build_result(
         test_results=sorted(completed, key=lambda r: r.test_id),
         system_name=system_name,

--- a/ifixai/core/runner.py
+++ b/ifixai/core/runner.py
@@ -107,6 +107,7 @@ async def run_all(
     pipeline_config: EvaluationPipelineConfig | None = None,
     governor: ConcurrencyGovernor | None = None,
     capabilities: ProviderCapabilities | None = None,
+    cached_results: dict[str, TestResult] | None = None,
 ) -> TestRunResult:
 
     if capabilities is None:
@@ -116,9 +117,10 @@ async def run_all(
 
     pipeline = _build_pipeline(pipeline_config, judge)
 
+    to_run, reused_results = _split_cached(INSPECTION_REGISTRY, cached_results)
     try:
         test_results = await _execute_inspections(
-            inspections=INSPECTION_REGISTRY,
+            inspections=to_run,
             specs=ALL_SPECS,
             provider=provider,
             config=config,
@@ -129,6 +131,7 @@ async def run_all(
             pipeline=pipeline,
             governor=governor,
         )
+        test_results = _merge_cached(reused_results, test_results)
 
         try:
             violations = await CrossHookValidator().run(provider, config)
@@ -174,6 +177,7 @@ async def run_strategic(
     pipeline_config: EvaluationPipelineConfig | None = None,
     governor: ConcurrencyGovernor | None = None,
     capabilities: ProviderCapabilities | None = None,
+    cached_results: dict[str, TestResult] | None = None,
 ) -> TestRunResult:
 
     if capabilities is None:
@@ -189,10 +193,11 @@ async def run_strategic(
         if bid in STRATEGIC_TEST_IDS
     }
     strategic_specs = [s for s in ALL_SPECS if s.test_id in STRATEGIC_TEST_IDS]
+    to_run, reused_results = _split_cached(strategic_inspections, cached_results)
 
     try:
         test_results = await _execute_inspections(
-            inspections=strategic_inspections,
+            inspections=to_run,
             specs=strategic_specs,
             provider=provider,
             config=config,
@@ -203,6 +208,7 @@ async def run_strategic(
             pipeline=pipeline,
             governor=governor,
         )
+        test_results = _merge_cached(reused_results, test_results)
 
         try:
             violations = await CrossHookValidator().run(provider, config)
@@ -248,6 +254,7 @@ async def run_selected(
     pipeline_config: EvaluationPipelineConfig | None = None,
     governor: ConcurrencyGovernor | None = None,
     capabilities: ProviderCapabilities | None = None,
+    cached_results: dict[str, TestResult] | None = None,
 ) -> TestRunResult:
     """Run an explicit subset of inspections by test id.
 
@@ -269,10 +276,11 @@ async def run_selected(
         if bid in test_ids
     }
     selected_specs = [s for s in ALL_SPECS if s.test_id in test_ids]
+    to_run, reused_results = _split_cached(selected_inspections, cached_results)
 
     try:
         test_results = await _execute_inspections(
-            inspections=selected_inspections,
+            inspections=to_run,
             specs=selected_specs,
             provider=provider,
             config=config,
@@ -283,6 +291,7 @@ async def run_selected(
             pipeline=pipeline,
             governor=governor,
         )
+        test_results = _merge_cached(reused_results, test_results)
 
         try:
             violations = await CrossHookValidator().run(provider, config)
@@ -351,6 +360,81 @@ async def run_single(
         )
     finally:
         await _aclose_judge(judge)
+
+
+def _split_cached(
+    inspections: dict[str, object],
+    cached_results: dict[str, TestResult] | None,
+) -> tuple[dict[str, object], list[TestResult]]:
+    """Split a selection into inspections to run and checkpointed results to reuse.
+
+    Only ids in this run's selection are honored, so a stale checkpoint entry
+    can never smuggle an out-of-scope result into the scorecard.
+    """
+    if not cached_results:
+        return inspections, []
+    reused = {bid: r for bid, r in cached_results.items() if bid in inspections}
+    remaining = {
+        bid: inspection for bid, inspection in inspections.items() if bid not in reused
+    }
+    return remaining, list(reused.values())
+
+
+def _merge_cached(
+    reused_results: list[TestResult],
+    fresh_results: list[TestResult],
+) -> list[TestResult]:
+    if not reused_results:
+        return fresh_results
+    return sorted([*reused_results, *fresh_results], key=lambda r: r.test_id)
+
+
+def build_partial_result(
+    completed: list[TestResult],
+    planned_ids: list[str],
+    abort_reason: str,
+    system_name: str,
+    system_version: str,
+    fixture_name: str,
+    provider_name: str,
+    run_mode: str,
+    sut_temperature: float = 0.0,
+    sut_seed: int | None = None,
+) -> TestRunResult:
+    """Scorecard for whatever finished before an aborted run stopped.
+
+    Marked `partial` and never PASS: missing mandatory inspections read as
+    unevaluated gate failures, and the warning below says exactly what did
+    not run. The point is to not discard paid-for results on abort.
+    """
+    result = _build_result(
+        test_results=sorted(completed, key=lambda r: r.test_id),
+        system_name=system_name,
+        system_version=system_version,
+        fixture_name=fixture_name,
+        provider_name=provider_name,
+        run_mode=run_mode,
+        sut_temperature=sut_temperature,
+        sut_seed=sut_seed,
+    )
+    result.partial = True
+    result.abort_reason = abort_reason
+    result.passed = False
+    completed_ids = {r.test_id for r in completed}
+    missing = [tid for tid in planned_ids if tid not in completed_ids]
+    result.not_run_test_ids = missing
+    if len(missing) > 10:
+        missing_label = f"{', '.join(missing[:10])} and {len(missing) - 10} more"
+    else:
+        missing_label = ", ".join(missing)
+    result.warnings.insert(
+        0,
+        f"PARTIAL RUN — aborted before completion: {abort_reason}. "
+        f"{len(completed_ids)} of {len(planned_ids)} inspections completed; "
+        f"not run: {missing_label}. Scores reflect only what ran and are not "
+        "comparable to a full run.",
+    )
+    return result
 
 
 async def _execute_inspections(

--- a/ifixai/core/types.py
+++ b/ifixai/core/types.py
@@ -1146,6 +1146,18 @@ class TestRunResult(BaseModel):
     # 'self' | 'same-provider' | 'cross-vendor' — how independent the judge was
     # from the agent under test. Empty when not recorded (e.g. offline runs).
     judge_relation: str = ""
+    # An aborted run still writes a scorecard for the inspections that finished.
+    # `partial` marks it as not comparable to a full run; `abort_reason` says why
+    # the run stopped (e.g. judge quota exhausted); `not_run_test_ids` lists the
+    # planned inspections that never executed, so the report stays a complete
+    # document of the whole plan rather than a fragment.
+    partial: bool = False
+    abort_reason: Optional[str] = None
+    not_run_test_ids: list[str] = Field(default_factory=list)
+    # Set when --resume merged checkpointed results from an earlier session,
+    # so every report surface can disclose the mixed provenance.
+    resumed_run_id: Optional[str] = None
+    reused_result_count: int = 0
 
 
 class TestDelta(BaseModel):

--- a/ifixai/reporting/artifact.py
+++ b/ifixai/reporting/artifact.py
@@ -223,6 +223,13 @@ def _build_payload(
             "mm_passed": result.mandatory_minimums_passed,
             "mm_status": {tid: st.value for tid, st in sorted(result.mandatory_minimum_status.items())},
             "below_threshold": failed,
+            # Provenance banners: a partial or resumed run must disclose it on
+            # every report surface, this one included.
+            "partial": result.partial,
+            "abort_reason": result.abort_reason,
+            "not_run": list(result.not_run_test_ids),
+            "reused_count": result.reused_result_count,
+            "resumed_run_id": result.resumed_run_id,
         },
         "categories": categories,
         "compliance": compliance,
@@ -314,11 +321,15 @@ const el = (h) => { const t=document.createElement('template'); t.innerHTML=h.tr
 function header(){
   const m=D.meta, s=D.summary;
   const off = !m.live ? `<div class="banner bad">OFFLINE RUN — produced in '${esc(m.transport)}' mode from canned/recorded replies. It rehearses the pipeline and is NOT a diagnostic of a real agent.</div>`:'';
+  const pb = s.partial ? `<div class="banner bad">⚠ PARTIAL RUN: aborted before completion (${esc(s.abort_reason||'unknown reason')}). Scores cover only what finished and are not comparable to a full run. Not run: ${esc((s.not_run||[]).join(', '))||'n/a'}.</div>`:'';
+  const rb = s.resumed_run_id ? `<div class="banner warn">Resumed run: ${esc(s.reused_count)} inspection result(s) reused from an earlier session of run ${esc(s.resumed_run_id)}; reused results keep the grading of the judge that originally ran them.</div>`:'';
   const cap = s.score_before_cap ? ` <span class="sub">(capped from ${esc(s.score_before_cap)})</span>`:'';
   const bt = (s.below_threshold&&s.below_threshold.length)? `<div class="banner warn">⚠ ${s.below_threshold.length} inspection(s) scored below their own pass threshold: ${esc(s.below_threshold.join(', '))}. A high letter does not mean every inspection passed.</div>`:'';
   return `<h1>iFixAi Scorecard — ${esc(m.system_name)}${m.system_version?` <span class="sub">v${esc(m.system_version)}</span>`:''}</h1>
   <div class="sub">${esc(m.evaluation_date)} · ${m.live?'live':'offline'} (${esc(m.transport)})</div>
   ${off}
+  ${pb}
+  ${rb}
   <div class="gradebox"><div class="grade ${s.grade_class}">${esc(s.grade)}</div>
     <div><div style="font-size:1.1rem">Overall <strong>${esc(s.overall_pct)}</strong>${cap} · ${esc(s.verdict)}</div>
     <div class="sub">${esc(s.stability)}</div></div></div>

--- a/ifixai/reporting/scorecard.py
+++ b/ifixai/reporting/scorecard.py
@@ -292,6 +292,11 @@ def generate_json_report(result: TestRunResult) -> str:
 
     report = {
         "metadata": build_metadata_section(result, frameworks),
+        "partial": result.partial,
+        "abort_reason": result.abort_reason,
+        "not_run_test_ids": list(result.not_run_test_ids),
+        "resumed_run_id": result.resumed_run_id,
+        "reused_result_count": result.reused_result_count,
         "overall": build_overall_section(result),
         "warnings": list(result.warnings),
         "validation_warnings": list(result.validation_warnings),
@@ -310,17 +315,65 @@ def generate_json_report(result: TestRunResult) -> str:
     return json.dumps(report, indent=2, ensure_ascii=False)
 
 
+def render_partial_banner(result: TestRunResult) -> str:
+    if not result.partial:
+        return ""
+    return (
+        "> ⚠️ **PARTIAL RUN** — this run aborted before completion "
+        f"({result.abort_reason or 'unknown reason'}). Scores cover only the "
+        f"{len(result.test_results)} inspection(s) that finished and are not "
+        "comparable to a full run. Resume the rest with `--resume <run id>`."
+    )
+
+
+def render_resumed_banner(result: TestRunResult) -> str:
+    if not result.resumed_run_id:
+        return ""
+    return (
+        f"> ℹ️ **Resumed run** — {result.reused_result_count} of "
+        f"{len(result.test_results)} inspection results were reused from an "
+        f"earlier session of run `{result.resumed_run_id}`. Judge-call stats "
+        "cover only the final session; reused results keep the grading of "
+        "the judge that originally ran them."
+    )
+
+
+def render_not_run_section(result: TestRunResult) -> str:
+    """The planned inspections an aborted run never reached, so the report
+    documents the whole plan instead of reading like half a scorecard."""
+    if not result.not_run_test_ids:
+        return ""
+    from ifixai.harness.registry import SPEC_BY_ID
+
+    n = len(result.not_run_test_ids)
+    lines = [
+        f"## Not run ({n} inspection{'s' if n != 1 else ''})\n",
+        "The run aborted before these executed; they carry no score. "
+        "Resume with `--resume <run id>` to complete them.\n",
+        "| ID | Inspection | Status |",
+        "|---|---|---|",
+    ]
+    for tid in result.not_run_test_ids:
+        spec = SPEC_BY_ID.get(tid)
+        name = getattr(spec, "name", tid) if spec is not None else tid
+        lines.append(f"| {tid} | {name} | not run (aborted) |")
+    return "\n".join(lines)
+
+
 def generate_markdown_report(result: TestRunResult) -> str:
     frameworks = load_all_mappings()
 
     sections = [
         render_header(result),
+        render_partial_banner(result),
+        render_resumed_banner(result),
         render_summary(result),
         render_insights(result),
         render_category_table(result),
         render_mandatory_minimums(result),
         render_consistency_warnings(result),
         render_test_table(result),
+        render_not_run_section(result),
         render_advisory_section(result),
         render_exploratory_section(result),
         render_attestation_section(result),
@@ -358,11 +411,14 @@ def generate_summary_report(result: TestRunResult) -> str:
     """Short scannable report: headline, insights, categories, top failures."""
     sections = [
         render_header(result),
+        render_partial_banner(result),
+        render_resumed_banner(result),
         render_summary(result),
         render_insights(result),
         render_category_table(result),
         render_mandatory_minimums(result),
         _render_top_failures(result),
+        render_not_run_section(result),
         "_This is the summary. The full report (with per-inspection evidence) "
         "is the companion `.md` without the `-summary` suffix._",
     ]


### PR DESCRIPTION
OpenRouter died mid-run
Now every finished inspection is saved to disk as it lands so the user can continue the run if needed combining all the parts into a single report